### PR TITLE
Add first-launch consent dialog

### DIFF
--- a/ride_aware_frontend/lib/app_initializer.dart
+++ b/ride_aware_frontend/lib/app_initializer.dart
@@ -5,6 +5,8 @@ import 'package:active_commuter_support/services/preferences_service.dart';
 import 'package:active_commuter_support/services/notification_service.dart';
 import 'package:flutter/material.dart';
 import 'package:active_commuter_support/services/device_id_service.dart';
+import 'package:active_commuter_support/services/consent_service.dart';
+import 'package:active_commuter_support/widgets/consent_dialog.dart';
 
 class AppInitializer extends StatefulWidget {
   const AppInitializer({super.key});
@@ -19,6 +21,7 @@ class _AppInitializerState extends State<AppInitializer> {
   final _preferencesService = PreferencesService();
   final _deviceIdService = DeviceIdService();
   final _notificationService = NotificationService();
+  final _consentService = ConsentService();
   bool _isLoading = true;
   bool _hasParticipantId = false;
   bool _thresholdsSet = false;
@@ -27,6 +30,8 @@ class _AppInitializerState extends State<AppInitializer> {
   void initState() {
     super.initState();
     _checkAppState();
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _showConsentDialogIfNeeded());
   }
 
   Future<void> _checkAppState() async {
@@ -63,6 +68,17 @@ class _AppInitializerState extends State<AppInitializer> {
       // ScaffoldMessenger.of(context).showSnackBar(
       //   SnackBar(content: Text('App initialization failed: $e')),
       // );
+    }
+  }
+
+  Future<void> _showConsentDialogIfNeeded() async {
+    final hasConsented = await _consentService.hasConsented();
+    if (!hasConsented && mounted) {
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => ConsentDialog(consentService: _consentService),
+      );
     }
   }
 

--- a/ride_aware_frontend/lib/services/consent_service.dart
+++ b/ride_aware_frontend/lib/services/consent_service.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ConsentService {
+  static const String _consentKey = 'user_consent';
+
+  Future<bool> hasConsented() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_consentKey) ?? false;
+  }
+
+  Future<void> setConsented(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_consentKey, value);
+  }
+}

--- a/ride_aware_frontend/lib/widgets/consent_dialog.dart
+++ b/ride_aware_frontend/lib/widgets/consent_dialog.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:active_commuter_support/services/consent_service.dart';
+
+class ConsentDialog extends StatelessWidget {
+  final ConsentService consentService;
+
+  const ConsentDialog({super.key, required this.consentService});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Before You Begin'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              Text(
+                  'This mobile app is part of a research study approved by the University of Strathclyde.'),
+              SizedBox(height: 8),
+              Text(
+                  'It explores how personalised weather alerts can support cyclists in making more confident commuting decisions.'),
+              SizedBox(height: 8),
+              Text('Participation is voluntary, and users may stop at any time.'),
+              SizedBox(height: 8),
+              Text('No live GPS or background tracking is used.'),
+              SizedBox(height: 8),
+              Text('Users may manually set a location or enable location services (optional).'),
+              SizedBox(height: 8),
+              Text('The app does not collect names, emails, or any identifiable data.'),
+              SizedBox(height: 8),
+              Text('Survey data is collected anonymously and cannot be linked to the user.'),
+              SizedBox(height: 8),
+              Text('All data handling complies with UK GDPR and the University of Strathclyde’s ethics policies.'),
+              SizedBox(height: 8),
+              Text(
+                  'For questions, users may contact Kripal Parsekar (kripal.parsekar.2024@uni.strath.ac.uk, +44 7823704105).'),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => exit(0),
+          child: const Text('I Do Not Consent'),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+            await consentService.setConsented(true);
+            if (context.mounted) {
+              Navigator.of(context).pop();
+            }
+          },
+          child: const Text('I Consent and Wish to Continue'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add consent service to persist user consent via SharedPreferences
- display non-dismissible consent dialog on first app launch with research study details
- refactor consent dialog into reusable widget for modularity

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e6e5746e483289b411adeb265f729