### PR TITLE
feat: map-based home and office location selection

### DIFF
--- a/ride_aware_frontend/lib/screens/location_picker_screen.dart
+++ b/ride_aware_frontend/lib/screens/location_picker_screen.dart
@@ -2,18 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
-class OfficeLocationPickerScreen extends StatefulWidget {
+class LocationPickerScreen extends StatefulWidget {
   final LatLng? initialLocation;
+  final String title;
 
-  const OfficeLocationPickerScreen({super.key, this.initialLocation});
+  const LocationPickerScreen({
+    super.key,
+    this.initialLocation,
+    required this.title,
+  });
 
   @override
-  State<OfficeLocationPickerScreen> createState() =>
-      _OfficeLocationPickerScreenState();
+  State<LocationPickerScreen> createState() => _LocationPickerScreenState();
 }
 
-class _OfficeLocationPickerScreenState
-    extends State<OfficeLocationPickerScreen> {
+class _LocationPickerScreenState extends State<LocationPickerScreen> {
   final MapController _mapController = MapController();
   LatLng _selectedLocation = const LatLng(51.5, -0.09); // Default to London
 
@@ -30,7 +33,7 @@ class _OfficeLocationPickerScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Select Office Location'),
+        title: Text(widget.title),
         centerTitle: true,
         actions: [
           TextButton(


### PR DESCRIPTION
## Summary
- add reusable `LocationPickerScreen` for map-based coordinate picking
- allow selecting home location on map or via current GPS
- reuse generic picker for office location and streamline route setup

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e77ac743883289ec59635a98a55ea