### PR TITLE
feat: add wind sensitivity thresholds

### DIFF
--- a/ride_aware_backend/models/thresholds.py
+++ b/ride_aware_backend/models/thresholds.py
@@ -9,6 +9,8 @@ class WeatherLimits(BaseModel):
     max_humidity: condecimal(gt=0, le=100)
     min_temperature: condecimal(gt=-50, le=60)
     max_temperature: condecimal(gt=-50, le=60)
+    headwind_sensitivity: condecimal(ge=0, le=50) = Field(default=20)
+    crosswind_sensitivity: condecimal(ge=0, le=50) = Field(default=15)
 
 class EnvironmentalRisk(BaseModel):
     min_visibility: condecimal(gt=0, le=20000)

--- a/ride_aware_backend/services/commute_status_service.py
+++ b/ride_aware_backend/services/commute_status_service.py
@@ -40,6 +40,12 @@ def get_commute_status(
         "max_humidity": float(thresholds.weather_limits.max_humidity),
         "min_temperature": float(thresholds.weather_limits.min_temperature),
         "max_temperature": float(thresholds.weather_limits.max_temperature),
+        "headwind_sensitivity": float(
+            thresholds.weather_limits.headwind_sensitivity
+        ),
+        "crosswind_sensitivity": float(
+            thresholds.weather_limits.crosswind_sensitivity
+        ),
     }
 
     # evaluate thresholds

--- a/ride_aware_backend/services/threshold_evaluator.py
+++ b/ride_aware_backend/services/threshold_evaluator.py
@@ -16,7 +16,7 @@ def evaluate_thresholds(
         results["time_exceeded"] = True
         results["details"]["commute_time"] = {
             "measured": commute_time,
-            "threshold": max_commute
+            "threshold": max_commute,
         }
 
     wind_limit = thresholds.get("max_wind_speed")
@@ -25,7 +25,33 @@ def evaluate_thresholds(
         results["weather_warning"] = True
         results["details"]["wind_speed"] = {
             "measured": wind_speed,
-            "threshold": wind_limit
+            "threshold": wind_limit,
+        }
+
+    headwind_limit = thresholds.get("headwind_sensitivity")
+    headwind_speed = weather_data.get("headwind_speed")
+    if (
+        headwind_limit is not None
+        and headwind_speed is not None
+        and headwind_speed > headwind_limit
+    ):
+        results["weather_warning"] = True
+        results["details"]["headwind_speed"] = {
+            "measured": headwind_speed,
+            "threshold": headwind_limit,
+        }
+
+    crosswind_limit = thresholds.get("crosswind_sensitivity")
+    crosswind_speed = weather_data.get("crosswind_speed")
+    if (
+        crosswind_limit is not None
+        and crosswind_speed is not None
+        and crosswind_speed > crosswind_limit
+    ):
+        results["weather_warning"] = True
+        results["details"]["crosswind_speed"] = {
+            "measured": crosswind_speed,
+            "threshold": crosswind_limit,
         }
 
     return results

--- a/ride_aware_frontend/lib/models/user_preferences.dart
+++ b/ride_aware_frontend/lib/models/user_preferences.dart
@@ -98,6 +98,8 @@ class WeatherLimits {
   final double maxHumidity;
   final double minTemperature;
   final double maxTemperature;
+  final double headwindSensitivity;
+  final double crosswindSensitivity;
 
   const WeatherLimits({
     required this.maxWindSpeed,
@@ -105,6 +107,8 @@ class WeatherLimits {
     required this.maxHumidity,
     required this.minTemperature,
     required this.maxTemperature,
+    required this.headwindSensitivity,
+    required this.crosswindSensitivity,
   });
 
   factory WeatherLimits.defaultValues() {
@@ -114,6 +118,8 @@ class WeatherLimits {
       maxHumidity: 85.0,
       minTemperature: 5.0, // 5°C minimum - cyclists don't like cold weather
       maxTemperature: 32.0,
+      headwindSensitivity: 20.0,
+      crosswindSensitivity: 15.0,
     );
   }
 
@@ -124,6 +130,10 @@ class WeatherLimits {
       maxHumidity: (json['max_humidity'] ?? 85.0).toDouble(),
       minTemperature: (json['min_temperature'] ?? 5.0).toDouble(),
       maxTemperature: (json['max_temperature'] ?? 32.0).toDouble(),
+      headwindSensitivity:
+          (json['headwind_sensitivity'] ?? 20.0).toDouble(),
+      crosswindSensitivity:
+          (json['crosswind_sensitivity'] ?? 15.0).toDouble(),
     );
   }
 
@@ -134,6 +144,8 @@ class WeatherLimits {
       'max_humidity': maxHumidity,
       'min_temperature': minTemperature,
       'max_temperature': maxTemperature,
+      'headwind_sensitivity': headwindSensitivity,
+      'crosswind_sensitivity': crosswindSensitivity,
     };
   }
 
@@ -143,6 +155,8 @@ class WeatherLimits {
     double? maxHumidity,
     double? minTemperature,
     double? maxTemperature,
+    double? headwindSensitivity,
+    double? crosswindSensitivity,
   }) {
     return WeatherLimits(
       maxWindSpeed: maxWindSpeed ?? this.maxWindSpeed,
@@ -150,6 +164,10 @@ class WeatherLimits {
       maxHumidity: maxHumidity ?? this.maxHumidity,
       minTemperature: minTemperature ?? this.minTemperature,
       maxTemperature: maxTemperature ?? this.maxTemperature,
+      headwindSensitivity:
+          headwindSensitivity ?? this.headwindSensitivity,
+      crosswindSensitivity:
+          crosswindSensitivity ?? this.crosswindSensitivity,
     );
   }
 
@@ -164,6 +182,10 @@ class WeatherLimits {
         minTemperature <= 60 &&
         maxTemperature >= -50 &&
         maxTemperature <= 60 &&
+        headwindSensitivity >= 0 &&
+        headwindSensitivity <= 50 &&
+        crosswindSensitivity >= 0 &&
+        crosswindSensitivity <= 50 &&
         minTemperature <=
             maxTemperature; // Min temp must be less than or equal to max temp
   }
@@ -176,7 +198,9 @@ class WeatherLimits {
         other.maxRainIntensity == maxRainIntensity &&
         other.maxHumidity == maxHumidity &&
         other.minTemperature == minTemperature &&
-        other.maxTemperature == maxTemperature;
+        other.maxTemperature == maxTemperature &&
+        other.headwindSensitivity == headwindSensitivity &&
+        other.crosswindSensitivity == crosswindSensitivity;
   }
 
   @override
@@ -185,12 +209,14 @@ class WeatherLimits {
         maxRainIntensity.hashCode ^
         maxHumidity.hashCode ^
         minTemperature.hashCode ^
-        maxTemperature.hashCode;
+        maxTemperature.hashCode ^
+        headwindSensitivity.hashCode ^
+        crosswindSensitivity.hashCode;
   }
 
   @override
   String toString() {
-    return 'WeatherLimits(maxWindSpeed: $maxWindSpeed, maxRainIntensity: $maxRainIntensity, maxHumidity: $maxHumidity, minTemperature: $minTemperature, maxTemperature: $maxTemperature)';
+    return 'WeatherLimits(maxWindSpeed: $maxWindSpeed, maxRainIntensity: $maxRainIntensity, maxHumidity: $maxHumidity, minTemperature: $minTemperature, maxTemperature: $maxTemperature, headwindSensitivity: $headwindSensitivity, crosswindSensitivity: $crosswindSensitivity)';
   }
 }
 

--- a/ride_aware_frontend/lib/screens/preferences_screen.dart
+++ b/ride_aware_frontend/lib/screens/preferences_screen.dart
@@ -41,6 +41,9 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   final _pollutionController = TextEditingController();
   final _uvIndexController = TextEditingController();
 
+  double _headwindSensitivity = 20.0;
+  double _crosswindSensitivity = 15.0;
+
   // Route specific controllers
   final _homeLatController = TextEditingController();
   final _homeLonController = TextEditingController();
@@ -110,6 +113,10 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         .toString();
     _maxTemperatureController.text = preferences.weatherLimits.maxTemperature
         .toString();
+    _headwindSensitivity =
+        preferences.weatherLimits.headwindSensitivity;
+    _crosswindSensitivity =
+        preferences.weatherLimits.crosswindSensitivity;
     _visibilityController.text = preferences.environmentalRisk.minVisibility
         .toString();
     _pollutionController.text = preferences.environmentalRisk.maxPollution
@@ -168,6 +175,8 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         maxHumidity: double.parse(_humidityController.text),
         minTemperature: double.parse(_minTemperatureController.text),
         maxTemperature: double.parse(_maxTemperatureController.text),
+        headwindSensitivity: _headwindSensitivity,
+        crosswindSensitivity: _crosswindSensitivity,
       ),
       environmentalRisk: EnvironmentalRisk(
         minVisibility: double.parse(_visibilityController.text),
@@ -609,6 +618,52 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
               helperText: '0 – 200 km/h',
               min: 0,
               max: 200,
+            ),
+            const SizedBox(height: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Headwind Sensitivity (${_headwindSensitivity.round()} km/h)',
+                ),
+                Slider(
+                  value: _headwindSensitivity,
+                  min: 0,
+                  max: 50,
+                  divisions: 50,
+                  label: '${_headwindSensitivity.round()} km/h',
+                  onChanged: (value) {
+                    setState(() => _headwindSensitivity = value);
+                  },
+                ),
+                Text(
+                  'Receive an alert when headwind exceeds this speed during your commute.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Crosswind Sensitivity (${_crosswindSensitivity.round()} km/h)',
+                ),
+                Slider(
+                  value: _crosswindSensitivity,
+                  min: 0,
+                  max: 50,
+                  divisions: 50,
+                  label: '${_crosswindSensitivity.round()} km/h',
+                  onChanged: (value) {
+                    setState(() => _crosswindSensitivity = value);
+                  },
+                ),
+                Text(
+                  'Receive an alert when crosswind exceeds this speed during your commute.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
             ),
             const SizedBox(height: 16),
             _buildNumberField(


### PR DESCRIPTION
## Summary
- extend backend and frontend models with headwind and crosswind sensitivity thresholds
- add sliders in preferences to capture wind sensitivity values
- include wind sensitivity in threshold evaluation and persistence

## Testing
- `flutter test` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e84ce749883289c03b784e62e79b3