### PR TITLE
Add comprehensive backend unit tests

### DIFF
--- a/ride_aware_backend/tests/conftest.py
+++ b/ride_aware_backend/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/ride_aware_backend/tests/controllers/test_commute_status_controller.py
+++ b/ride_aware_backend/tests/controllers/test_commute_status_controller.py
@@ -1,0 +1,15 @@
+from controllers.commute_status_controller import get_status
+
+
+def test_get_status(monkeypatch):
+    thresholds = object()
+    called = {}
+
+    def fake_service(arg):
+        called['arg'] = arg
+        return {'ok': True}
+
+    monkeypatch.setattr('controllers.commute_status_controller.get_commute_status', fake_service)
+    result = get_status(thresholds)
+    assert result == {'ok': True}
+    assert called['arg'] is thresholds

--- a/ride_aware_backend/tests/controllers/test_route_controller.py
+++ b/ride_aware_backend/tests/controllers/test_route_controller.py
@@ -1,0 +1,45 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from controllers import route_controller
+from models.route import RouteModel, GeoPoint
+
+
+def test_save_user_route(monkeypatch):
+    route = RouteModel(
+        device_id="device123",
+        route_name="Route",
+        start_location=GeoPoint(latitude=1, longitude=2),
+        end_location=GeoPoint(latitude=3, longitude=4),
+        route_points=[GeoPoint(latitude=1, longitude=2)],
+    )
+
+    dummy_result = object()
+    collection = type("C", (), {"update_one": AsyncMock(return_value=dummy_result)})()
+    monkeypatch.setattr(route_controller, "routes_collection", collection)
+
+    result = asyncio.run(route_controller.save_user_route(route))
+    collection.update_one.assert_called_once()
+    assert result == {"status": "ok", "device_id": "device123"}
+
+
+def test_get_user_route(monkeypatch):
+    doc = {
+        "device_id": "device123",
+        "route_name": "Route",
+        "start_location": {"latitude": 1, "longitude": 2},
+        "end_location": {"latitude": 3, "longitude": 4},
+        "route_points": [{"latitude": 1, "longitude": 2}],
+    }
+    collection = type("C", (), {"find_one": AsyncMock(return_value=doc)})()
+    monkeypatch.setattr(route_controller, "routes_collection", collection)
+    result = asyncio.run(route_controller.get_user_route("device123"))
+    assert result["device_id"] == "device123"
+
+
+def test_get_user_route_not_found(monkeypatch):
+    collection = type("C", (), {"find_one": AsyncMock(return_value=None)})()
+    monkeypatch.setattr(route_controller, "routes_collection", collection)
+    with pytest.raises(route_controller.HTTPException):
+        asyncio.run(route_controller.get_user_route("device123"))

--- a/ride_aware_backend/tests/controllers/test_threshold_controller.py
+++ b/ride_aware_backend/tests/controllers/test_threshold_controller.py
@@ -1,0 +1,63 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from controllers import threshold_controller
+from models.thresholds import Thresholds, WeatherLimits, EnvironmentalRisk, OfficeLocation
+
+
+def test_upsert_threshold(monkeypatch):
+    thresholds = Thresholds(
+        device_id="device123",
+        weather_limits=WeatherLimits(
+            max_wind_speed=10,
+            max_rain_intensity=5,
+            max_humidity=80,
+            min_temperature=0,
+            max_temperature=35,
+        ),
+        environmental_risk=EnvironmentalRisk(
+            min_visibility=1000,
+            max_pollution=100,
+            max_uv_index=8,
+        ),
+        office_location=OfficeLocation(latitude=0, longitude=0),
+    )
+    result_obj = type("R", (), {"modified_count": 1, "upserted_id": "id"})()
+    collection = type("C", (), {"update_one": AsyncMock(return_value=result_obj)})()
+    monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
+    result = asyncio.run(threshold_controller.upsert_threshold(thresholds))
+    collection.update_one.assert_called_once()
+    assert result["status"] == "ok"
+
+
+def test_get_thresholds(monkeypatch):
+    doc = {
+        "device_id": "device123",
+        "weather_limits": {
+            "max_wind_speed": 10,
+            "max_rain_intensity": 5,
+            "max_humidity": 80,
+            "min_temperature": 0,
+            "max_temperature": 35,
+            "headwind_sensitivity": 20,
+            "crosswind_sensitivity": 15,
+        },
+        "environmental_risk": {
+            "min_visibility": 1000,
+            "max_pollution": 100,
+            "max_uv_index": 8,
+        },
+        "office_location": {"latitude": 0, "longitude": 0},
+    }
+    collection = type("C", (), {"find_one": AsyncMock(return_value=dict(doc))})()
+    monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
+    result = asyncio.run(threshold_controller.get_thresholds("device123"))
+    assert result["device_id"] == "device123"
+
+
+def test_get_thresholds_not_found(monkeypatch):
+    collection = type("C", (), {"find_one": AsyncMock(return_value=None)})()
+    monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
+    with pytest.raises(threshold_controller.HTTPException):
+        asyncio.run(threshold_controller.get_thresholds("device123"))

--- a/ride_aware_backend/tests/models/test_models.py
+++ b/ride_aware_backend/tests/models/test_models.py
@@ -1,0 +1,78 @@
+import pytest
+from pydantic import ValidationError
+
+from models.fcm import FCMDeviceModel
+from models.route import RouteModel, GeoPoint
+from models.thresholds import Thresholds, WeatherLimits, EnvironmentalRisk, OfficeLocation
+
+
+def test_fcm_device_model_valid():
+    model = FCMDeviceModel(device_id="abc123", fcm_token="token")
+    assert model.device_id == "abc123"
+
+
+def test_fcm_device_model_invalid():
+    with pytest.raises(ValidationError):
+        FCMDeviceModel(device_id="abc123")
+
+
+def test_route_model_validation():
+    route = RouteModel(
+        device_id="device123",
+        route_name="Route",
+        start_location=GeoPoint(latitude=0, longitude=0),
+        end_location=GeoPoint(latitude=1, longitude=1),
+        route_points=[GeoPoint(latitude=0, longitude=0)],
+    )
+    assert route.device_id == "device123"
+
+
+def test_route_model_invalid_latitude():
+    with pytest.raises(ValidationError):
+        RouteModel(
+            device_id="device123",
+            route_name="Route",
+            start_location=GeoPoint(latitude=100, longitude=0),
+            end_location=GeoPoint(latitude=1, longitude=1),
+            route_points=[],
+        )
+
+
+def test_thresholds_model_valid():
+    thresholds = Thresholds(
+        device_id="device123",
+        weather_limits=WeatherLimits(
+            max_wind_speed=10,
+            max_rain_intensity=5,
+            max_humidity=80,
+            min_temperature=0,
+            max_temperature=35,
+        ),
+        environmental_risk=EnvironmentalRisk(
+            min_visibility=1000,
+            max_pollution=100,
+            max_uv_index=8,
+        ),
+        office_location=OfficeLocation(latitude=0, longitude=0),
+    )
+    assert thresholds.device_id == "device123"
+
+
+def test_thresholds_model_invalid_device_id():
+    with pytest.raises(ValidationError):
+        Thresholds(
+            device_id="dev",
+            weather_limits=WeatherLimits(
+                max_wind_speed=10,
+                max_rain_intensity=5,
+                max_humidity=80,
+                min_temperature=0,
+                max_temperature=35,
+            ),
+            environmental_risk=EnvironmentalRisk(
+                min_visibility=1000,
+                max_pollution=100,
+                max_uv_index=8,
+            ),
+            office_location=OfficeLocation(latitude=0, longitude=0),
+        )

--- a/ride_aware_backend/tests/services/test_commute_status_service.py
+++ b/ride_aware_backend/tests/services/test_commute_status_service.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from models.thresholds import Thresholds, WeatherLimits, EnvironmentalRisk, OfficeLocation
+
+
+def test_get_commute_status(monkeypatch):
+    from services import commute_status_service as css
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2023, 1, 1, 8, 30)
+
+    monkeypatch.setattr(css, "datetime", FixedDateTime)
+    monkeypatch.setattr(css, "get_hourly_forecast", lambda *a, **k: {"wind_speed": 5})
+    monkeypatch.setattr(css, "evaluate_thresholds", lambda *a, **k: {"time_exceeded": False, "weather_warning": False})
+    monkeypatch.setattr(css, "generate_recommendations", lambda *a, **k: ["All good"])
+
+    thresholds = Thresholds(
+        device_id="device123",
+        weather_limits=WeatherLimits(
+            max_wind_speed=10,
+            max_rain_intensity=5,
+            max_humidity=80,
+            min_temperature=0,
+            max_temperature=35,
+        ),
+        environmental_risk=EnvironmentalRisk(
+            min_visibility=1000,
+            max_pollution=100,
+            max_uv_index=8,
+        ),
+        office_location=OfficeLocation(latitude=0, longitude=0),
+    )
+
+    result = css.get_commute_status(thresholds)
+    assert result["in_commute_window"] is True
+    assert result["suggestions"] == ["All good"]

--- a/ride_aware_backend/tests/services/test_recommendation_engine.py
+++ b/ride_aware_backend/tests/services/test_recommendation_engine.py
@@ -1,0 +1,14 @@
+from services.recommendation_engine import generate_recommendations
+
+
+def test_generate_recommendations_default():
+    evaluation = {"time_exceeded": True, "weather_warning": True}
+    suggestions = generate_recommendations(evaluation)
+    assert "Consider leaving earlier." in suggestions
+    assert "Bring an umbrella." in suggestions
+
+
+def test_generate_recommendations_custom():
+    evaluation = {"foo": True}
+    rules = {"foo": ["bar"]}
+    assert generate_recommendations(evaluation, rules) == ["bar"]

--- a/ride_aware_backend/tests/services/test_threshold_evaluator.py
+++ b/ride_aware_backend/tests/services/test_threshold_evaluator.py
@@ -1,0 +1,21 @@
+from services.threshold_evaluator import evaluate_thresholds
+
+
+def test_evaluate_thresholds_flags():
+    thresholds = {
+        "max_commute_minutes": 30,
+        "max_wind_speed": 5,
+        "headwind_sensitivity": 10,
+        "crosswind_sensitivity": 7,
+    }
+    weather = {"wind_speed": 6, "headwind_speed": 11, "crosswind_speed": 8}
+    result = evaluate_thresholds(40, weather, thresholds)
+    assert result["time_exceeded"]
+    assert result["weather_warning"]
+    assert "wind_speed" in result["details"]
+
+
+def test_evaluate_thresholds_no_flags():
+    result = evaluate_thresholds(10, {}, {})
+    assert not result["time_exceeded"]
+    assert not result["weather_warning"]

--- a/ride_aware_backend/tests/services/test_weather_service.py
+++ b/ride_aware_backend/tests/services/test_weather_service.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+import pytest
+
+
+def make_response(data):
+    class Resp:
+        def __init__(self, d):
+            self._d = d
+        def json(self):
+            return self._d
+        def raise_for_status(self):
+            pass
+    return Resp(data)
+
+
+def test_get_hourly_forecast(monkeypatch):
+    from services import weather_service
+    dt = datetime(2023, 1, 1, 12, 0)
+    hourly = [{"dt": int(dt.timestamp()), "temp": 270}]
+    monkeypatch.setattr(weather_service.requests, "get", lambda url: make_response({"hourly": hourly}))
+    res = weather_service.get_hourly_forecast("1,2", dt, "key")
+    assert res["temp"] == 270
+
+
+def test_get_hourly_forecast_no_match(monkeypatch):
+    from services import weather_service
+    dt = datetime(2023, 1, 1, 12, 0)
+    hourly = [{"dt": int(dt.timestamp()) + 7200, "temp": 270}]
+    monkeypatch.setattr(weather_service.requests, "get", lambda url: make_response({"hourly": hourly}))
+    with pytest.raises(ValueError):
+        weather_service.get_hourly_forecast("1,2", dt, "key")

--- a/ride_aware_backend/tests/utils/test_commute_window.py
+++ b/ride_aware_backend/tests/utils/test_commute_window.py
@@ -1,0 +1,31 @@
+from datetime import datetime, time, timedelta
+
+from utils.commute_window import (
+    parse_time,
+    is_within_commute_window,
+    commute_window_duration,
+)
+
+
+def test_parse_time():
+    assert parse_time("08:30") == time(8, 30)
+
+
+def test_is_within_commute_window_normal():
+    start = time(8, 0)
+    end = time(9, 0)
+    assert is_within_commute_window(datetime(2023, 1, 1, 8, 30), start, end)
+    assert not is_within_commute_window(datetime(2023, 1, 1, 10, 0), start, end)
+
+
+def test_is_within_commute_window_wraparound():
+    start = time(22, 0)
+    end = time(2, 0)
+    assert is_within_commute_window(datetime(2023, 1, 1, 23, 0), start, end)
+    assert is_within_commute_window(datetime(2023, 1, 2, 1, 0), start, end)
+    assert not is_within_commute_window(datetime(2023, 1, 2, 3, 0), start, end)
+
+
+def test_commute_window_duration():
+    assert commute_window_duration(time(8, 0), time(9, 0)) == timedelta(hours=1)
+    assert commute_window_duration(time(22, 0), time(2, 0)) == timedelta(hours=4)

--- a/ride_aware_backend/tests/utils/test_routing.py
+++ b/ride_aware_backend/tests/utils/test_routing.py
@@ -1,0 +1,8 @@
+from decimal import Decimal
+
+from utils.routing import convert_decimal_to_float
+
+
+def test_convert_decimal_to_float():
+    data = {"a": Decimal("1.2"), "b": [Decimal("3.4"), {"c": Decimal("5.6")}]}
+    assert convert_decimal_to_float(data) == {"a": 1.2, "b": [3.4, {"c": 5.6}]}

--- a/ride_aware_backend/tests/utils/test_weather.py
+++ b/ride_aware_backend/tests/utils/test_weather.py
@@ -1,0 +1,34 @@
+import os
+from datetime import datetime
+import pytest
+
+
+def make_response(data):
+    class Response:
+        def __init__(self, json_data):
+            self._json = json_data
+        def json(self):
+            return self._json
+        def raise_for_status(self):
+            pass
+    return Response(data)
+
+
+def test_get_hourly_forecast(monkeypatch):
+    monkeypatch.setenv("OWM_API_KEY", "key")
+    from utils.weather import get_hourly_forecast
+    dt = datetime(2023, 1, 1, 12, 0)
+    hourly = [{"dt": int(dt.timestamp()), "temp": 280}]
+    monkeypatch.setattr("utils.weather.requests.get", lambda url: make_response({"hourly": hourly}))
+    result = get_hourly_forecast("1,2", dt)
+    assert result["temp"] == 280
+
+
+def test_get_hourly_forecast_no_match(monkeypatch):
+    monkeypatch.setenv("OWM_API_KEY", "key")
+    from utils.weather import get_hourly_forecast
+    dt = datetime(2023, 1, 1, 12, 0)
+    hourly = [{"dt": int(dt.timestamp()) + 7200, "temp": 280}]
+    monkeypatch.setattr("utils.weather.requests.get", lambda url: make_response({"hourly": hourly}))
+    with pytest.raises(ValueError):
+        get_hourly_forecast("1,2", dt)


### PR DESCRIPTION
## Summary
- add unit tests for utility functions like time parsing, routing helpers, and weather retrieval
- cover service logic including commute status evaluation, threshold checks, and recommendations
- test controllers and Pydantic models with mocked dependencies

## Testing
- `cd ride_aware_backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eaa2af29c832893385143bbe429f4