### PR TITLE
feat: handle missing openweather key

### DIFF
--- a/ride_aware_backend/routes/commute_status.py
+++ b/ride_aware_backend/routes/commute_status.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from controllers.commute_status_controller import get_status
+from services.weather_service import MissingAPIKeyError
+
 
 router = APIRouter(prefix="/commute", tags=["commute"])
 
@@ -11,5 +13,8 @@ async def commute_status(device_id: str):
         return await get_status(device_id)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except MissingAPIKeyError as e:
+        raise HTTPException(status_code=500, detail=str(e))
     except Exception:
         raise HTTPException(status_code=500, detail="Internal server error")
+

--- a/ride_aware_backend/services/weather_service.py
+++ b/ride_aware_backend/services/weather_service.py
@@ -7,6 +7,10 @@ from typing import Dict
 import requests
 
 
+class MissingAPIKeyError(Exception):
+    """Raised when the OpenWeather API key is missing."""
+
+
 OPENWEATHER_URL = "https://api.openweathermap.org/data/3.0/onecall"
 
 
@@ -27,7 +31,7 @@ def get_hourly_forecast(lat: float, lon: float, target_time: datetime) -> Dict:
     """
     api_key = os.getenv("OPENWEATHER_API_KEY")
     if not api_key:
-        raise RuntimeError("OPENWEATHER_API_KEY environment variable not set")
+        raise MissingAPIKeyError("OPENWEATHER_API_KEY environment variable not set")
 
     params = {
         "lat": lat,

--- a/ride_aware_backend/tests/routes/test_commute_status_route.py
+++ b/ride_aware_backend/tests/routes/test_commute_status_route.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+from routes import commute_status
+from services.weather_service import MissingAPIKeyError
+
+
+def test_commute_status_missing_api_key(monkeypatch):
+    async def fake_get_status(device_id: str):
+        raise MissingAPIKeyError("OPENWEATHER_API_KEY environment variable not set")
+
+    monkeypatch.setattr(commute_status, "get_status", fake_get_status)
+
+    app = FastAPI()
+    app.include_router(commute_status.router)
+    client = TestClient(app)
+
+    resp = client.get("/commute/status/abc")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "OPENWEATHER_API_KEY environment variable not set"
+

--- a/ride_aware_backend/tests/services/test_weather_service.py
+++ b/ride_aware_backend/tests/services/test_weather_service.py
@@ -30,3 +30,10 @@ def test_get_hourly_forecast_no_data(monkeypatch):
     monkeypatch.setattr(weather_service.requests, "get", lambda url, params=None: make_response({"hourly": []}))
     with pytest.raises(ValueError):
         weather_service.get_hourly_forecast(1.0, 2.0, dt)
+
+
+def test_get_hourly_forecast_missing_api_key(monkeypatch):
+    dt = datetime(2023, 1, 1, 12, 0)
+    monkeypatch.delenv("OPENWEATHER_API_KEY", raising=False)
+    with pytest.raises(weather_service.MissingAPIKeyError):
+        weather_service.get_hourly_forecast(1.0, 2.0, dt)


### PR DESCRIPTION
## Summary
- add explicit MissingAPIKeyError in weather_service when OPENWEATHER_API_KEY is absent
- surface MissingAPIKeyError through commute status route with descriptive message
- test weather service and route behavior when API key is missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ebd8255988328b92b2db6bad218f3