### PR TITLE
Add structured logging across backend

### DIFF
--- a/ride_aware_backend/controllers/commute_status_controller.py
+++ b/ride_aware_backend/controllers/commute_status_controller.py
@@ -1,6 +1,12 @@
+import logging
 from services.commute_status_service import get_commute_status
+
+
+logger = logging.getLogger(__name__)
 
 
 async def get_status(device_id: str) -> dict:
     """Controller layer for commute status retrieval."""
+    logger.info("Getting commute status for device %s", device_id)
     return await get_commute_status(device_id)
+

--- a/ride_aware_backend/controllers/route_controller.py
+++ b/ride_aware_backend/controllers/route_controller.py
@@ -1,25 +1,36 @@
+import logging
 from fastapi import HTTPException
 from models.route import RouteModel
 from services.db import routes_collection
 from pymongo.errors import PyMongoError
 
+
+logger = logging.getLogger(__name__)
+
+
 async def save_user_route(route: RouteModel):
     try:
-        result = await routes_collection.update_one(
+        await routes_collection.update_one(
             {"device_id": route.device_id},
             {"$set": route.model_dump(mode='json')},
-            upsert=True
+            upsert=True,
         )
+        logger.info("Route upserted for device %s", route.device_id)
         return {"status": "ok", "device_id": route.device_id}
     except PyMongoError as e:
+        logger.error("Database error saving route for %s: %s", route.device_id, e)
         raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")
 
+
 async def get_user_route(device_id: str) -> dict:
+    logger.info("Retrieving route for device %s", device_id)
     doc = await routes_collection.find_one({"device_id": device_id})
     if not doc:
+        logger.warning("Route not found for device %s", device_id)
         raise HTTPException(status_code=404, detail="Route not found")
 
     doc.pop("_id", None)
-    print(doc)
+    logger.debug("Route document for %s: %s", device_id, doc)
     return RouteModel(**doc).model_dump(mode="json")
+
 

--- a/ride_aware_backend/controllers/threshold_controller.py
+++ b/ride_aware_backend/controllers/threshold_controller.py
@@ -1,30 +1,46 @@
+import logging
 from fastapi import HTTPException
 from models.thresholds import Thresholds
 from services.db import thresholds_collection
 
+
+logger = logging.getLogger(__name__)
+
+
 async def upsert_threshold(threshold: Thresholds) -> dict:
     data = threshold.model_dump(mode="json")
     device_id = data["device_id"]
+    logger.info("Upserting thresholds for device %s", device_id)
 
     result = await thresholds_collection.update_one(
         {"device_id": device_id},
         {"$set": data},
-        upsert=True
+        upsert=True,
+    )
+    logger.info("Thresholds upserted for device %s", device_id)
+    logger.debug(
+        "Upsert result for %s: modified=%s upserted_id=%s",
+        device_id,
+        getattr(result, "modified_count", None),
+        getattr(result, "upserted_id", None),
     )
 
     return {
         "device_id": device_id,
         "status": "ok",
-        "modified_count": result.modified_count,
-        "upserted_id": str(result.upserted_id) if result.upserted_id else None
+        "modified_count": getattr(result, "modified_count", None),
+        "upserted_id": str(getattr(result, "upserted_id", "")) or None,
     }
 
 
 async def get_thresholds(device_id: str) -> dict:
+    logger.info("Retrieving thresholds for device %s", device_id)
     doc = await thresholds_collection.find_one({"device_id": device_id})
     if not doc:
+        logger.warning("Thresholds not found for device %s", device_id)
         raise HTTPException(status_code=404, detail="Thresholds not found")
 
     # Remove _id and validate through model
     doc.pop("_id", None)
     return Thresholds(**doc).model_dump(mode="json")
+

--- a/ride_aware_backend/main.py
+++ b/ride_aware_backend/main.py
@@ -1,7 +1,16 @@
+import logging
 from fastapi import FastAPI
 from routes import thresholds, routes, fcm, commute_status
 
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
 app = FastAPI()
+logger.info("FastAPI application initialized")
 app.include_router(thresholds.router)
 app.include_router(routes.router)
 app.include_router(fcm.router)

--- a/ride_aware_backend/routes/commute_status.py
+++ b/ride_aware_backend/routes/commute_status.py
@@ -5,19 +5,24 @@ from controllers.commute_status_controller import get_status
 from services.weather_service import MissingAPIKeyError
 
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/commute", tags=["commute"])
 
 
 @router.get("/status/{device_id}")
 async def commute_status(device_id: str):
     """Return commute status for the specified device."""
+    logger.info("Requesting commute status for device %s", device_id)
     try:
         return await get_status(device_id)
     except ValueError as e:
+        logger.warning("Thresholds not found for device %s: %s", device_id, e)
         raise HTTPException(status_code=404, detail=str(e))
-
     except MissingAPIKeyError as e:
+        logger.error("Weather service configuration error: %s", e)
         raise HTTPException(status_code=500, detail=str(e))
     except Exception:
+        logger.exception("Unexpected error retrieving commute status for %s", device_id)
         raise HTTPException(status_code=500, detail="Internal server error")
+
 

--- a/ride_aware_backend/routes/fcm.py
+++ b/ride_aware_backend/routes/fcm.py
@@ -1,14 +1,21 @@
+import logging
 from fastapi import APIRouter
 from models.fcm import FCMDeviceModel
 from services.db import fcm_tokens_collection
 
+
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/fcm", tags=["FCM"])
+
 
 @router.post("/register/")
 async def register_fcm_token(data: FCMDeviceModel):
+    logger.info("Registering FCM token for device %s", data.device_id)
     await fcm_tokens_collection.update_one(
         {"device_id": data.device_id},
         {"$set": {"fcm_token": data.fcm_token}},
-        upsert=True
+        upsert=True,
     )
+    logger.debug("FCM token stored for device %s", data.device_id)
     return {"status": "success", "message": "FCM token registered."}
+

--- a/ride_aware_backend/routes/routes.py
+++ b/ride_aware_backend/routes/routes.py
@@ -1,16 +1,21 @@
+import logging
 from fastapi import APIRouter
 from models.route import RouteModel
-from controllers.route_controller import *
+from controllers.route_controller import save_user_route, get_user_route
 
+
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/routes", tags=["Routes"])
 
 
-@router.post("",include_in_schema=False)
+@router.post("", include_in_schema=False)
 @router.post("/")
 async def create_user_route(route: RouteModel):
-    print(1)
+    logger.info("Saving route for device %s", route.device_id)
     return await save_user_route(route)
+
 
 @router.get("/{device_id}")
 async def fetch_user_route(device_id: str):
+    logger.info("Fetching route for device %s", device_id)
     return await get_user_route(device_id)

--- a/ride_aware_backend/routes/thresholds.py
+++ b/ride_aware_backend/routes/thresholds.py
@@ -1,13 +1,22 @@
+import logging
 from fastapi import APIRouter
-from controllers.threshold_controller import *
+from models.thresholds import Thresholds
+from controllers.threshold_controller import upsert_threshold, get_thresholds
 
+
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/thresholds", tags=["Thresholds"])
+
 
 @router.post("", include_in_schema=False)
 @router.post("/")
 async def set_threshold(threshold: Thresholds):
+    logger.info("Setting thresholds for device %s", threshold.device_id)
     return await upsert_threshold(threshold)
+
 
 @router.get("/{device_id}")
 async def fetch_threshold(device_id: str):
+    logger.info("Fetching thresholds for device %s", device_id)
     return await get_thresholds(device_id)
+

--- a/ride_aware_backend/services/commute_evaluator.py
+++ b/ride_aware_backend/services/commute_evaluator.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
 from typing import List
 
 from models.thresholds import WeatherLimits
+
+
+logger = logging.getLogger(__name__)
 
 
 def evaluate_thresholds(weather_data: dict, thresholds: WeatherLimits) -> List[str]:
@@ -57,4 +61,6 @@ def evaluate_thresholds(weather_data: dict, thresholds: WeatherLimits) -> List[s
     ):
         messages.append("Pollution exceeds your comfort limit")
 
+    logger.debug("Threshold evaluation messages: %s", messages)
     return messages
+

--- a/ride_aware_backend/services/db.py
+++ b/ride_aware_backend/services/db.py
@@ -1,7 +1,11 @@
+import logging
 from motor.motor_asyncio import AsyncIOMotorClient
 from config import MONGO_URI
 
+logger = logging.getLogger(__name__)
+
 client = AsyncIOMotorClient(MONGO_URI)
+logger.info("Connected to MongoDB at %s", MONGO_URI)
 db = client['acs']
 
 thresholds_collection = db["thresholds"]

--- a/ride_aware_backend/services/recommendation_engine.py
+++ b/ride_aware_backend/services/recommendation_engine.py
@@ -1,26 +1,32 @@
 from typing import Dict, Any, List
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def generate_recommendations(
     evaluation: Dict[str, Any],
-    rules: Dict[str, List[str]] = None
+    rules: Dict[str, List[str]] = None,
 ) -> List[str]:
     """
     Generate user suggestions based on evaluation results.
     """
+    logger.debug("Generating recommendations from evaluation: %s", evaluation)
     default_rules: Dict[str, List[str]] = {
         "time_exceeded": [
             "Consider leaving earlier.",
-            "Check for faster routes."
+            "Check for faster routes.",
         ],
         "weather_warning": [
             "Bring an umbrella.",
-            "Allow extra travel time due to weather."
-        ]
+            "Allow extra travel time due to weather.",
+        ],
     }
     suggestions: List[str] = []
     lookup = rules or default_rules
     for key, flagged in evaluation.items():
         if flagged and key in lookup:
             suggestions.extend(lookup[key])
+    logger.debug("Generated suggestions: %s", suggestions)
     return suggestions

--- a/ride_aware_backend/services/weather_service.py
+++ b/ride_aware_backend/services/weather_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 import os
 from typing import Dict
@@ -12,6 +13,7 @@ class MissingAPIKeyError(Exception):
 
 
 OPENWEATHER_URL = "https://api.openweathermap.org/data/3.0/onecall"
+logger = logging.getLogger(__name__)
 
 
 def get_hourly_forecast(lat: float, lon: float, target_time: datetime) -> Dict:
@@ -29,8 +31,15 @@ def get_hourly_forecast(lat: float, lon: float, target_time: datetime) -> Dict:
     dict
         Dictionary containing key weather metrics for the closest hour.
     """
+    logger.info(
+        "Fetching weather forecast for lat=%s lon=%s at %s",
+        lat,
+        lon,
+        target_time,
+    )
     api_key = os.getenv("OPENWEATHER_API_KEY")
     if not api_key:
+        logger.error("OPENWEATHER_API_KEY environment variable not set")
         raise MissingAPIKeyError("OPENWEATHER_API_KEY environment variable not set")
 
     params = {
@@ -40,21 +49,32 @@ def get_hourly_forecast(lat: float, lon: float, target_time: datetime) -> Dict:
         "exclude": "current,minutely,daily,alerts",
     }
     response = requests.get(OPENWEATHER_URL, params=params)
+    logger.debug(
+        "Weather API response status: %s", getattr(response, "status_code", "unknown")
+    )
     response.raise_for_status()
     hourly = response.json().get("hourly", [])
     if not hourly:
+        logger.error("No hourly data available from weather service")
         raise ValueError("No hourly data available")
 
     target_ts = int(target_time.timestamp())
     closest = min(hourly, key=lambda h: abs(h.get("dt", 0) - target_ts))
 
-    return {
+    data = {
         "wind_speed": closest.get("wind_speed"),
         "wind_deg": closest.get("wind_deg"),
-        "rain": (closest.get("rain", {}).get("1h") if isinstance(closest.get("rain"), dict) else closest.get("rain")),
+        "rain": (
+            closest.get("rain", {}).get("1h")
+            if isinstance(closest.get("rain"), dict)
+            else closest.get("rain")
+        ),
         "humidity": closest.get("humidity"),
         "temp": closest.get("temp"),
         "visibility": closest.get("visibility"),
         "uvi": closest.get("uvi"),
         "clouds": closest.get("clouds"),
     }
+    logger.debug("Selected weather data: %s", data)
+    return data
+


### PR DESCRIPTION
## Summary
- configure root logging in `main.py`
- add info and debug logs to routes, controllers, and services to trace operations and errors
- remove print statements and log database connections and external API interactions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec0a0ef0c8328a85f80df6924d8f3