### PR TITLE
feat: make OpenWeather endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # ride-aware-mvp
+
+## Configuration
+
+The backend requires several environment variables:
+
+- `OPENWEATHER_API_KEY` – API key for accessing OpenWeather data.
+- `OPENWEATHER_URL` *(optional)* – Base URL for the OpenWeather One Call API.
+  Defaults to the free endpoint `https://api.openweathermap.org/data/2.5/onecall`.
+
+## Deployment
+
+Ensure `OPENWEATHER_API_KEY` is set in the environment where the backend runs.
+`OPENWEATHER_URL` may be overridden if pointing to a different OpenWeather
+instance; otherwise, it falls back to the free v2.5 endpoint listed above.

--- a/ride_aware_backend/services/weather_service.py
+++ b/ride_aware_backend/services/weather_service.py
@@ -11,8 +11,9 @@ import requests
 class MissingAPIKeyError(Exception):
     """Raised when the OpenWeather API key is missing."""
 
-
-OPENWEATHER_URL = "https://api.openweathermap.org/data/3.0/onecall"
+OPENWEATHER_URL = os.getenv(
+    "OPENWEATHER_URL", "https://api.openweathermap.org/data/2.5/onecall"
+)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- make OpenWeather endpoint configurable via `OPENWEATHER_URL`
- document weather service configuration
- align weather service tests with v2.5 free endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec4b060648328a99c836a96d5e505