### PR TITLE
Use OpenWeather free forecast endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 The backend requires several environment variables:
 
 - `OPENWEATHER_API_KEY` – API key for accessing OpenWeather data.
-- `OPENWEATHER_URL` *(optional)* – Base URL for the OpenWeather One Call API.
-  Defaults to the free endpoint `https://api.openweathermap.org/data/2.5/onecall`.
+- `OPENWEATHER_URL` *(optional)* – Base URL for the OpenWeather 5-day forecast API.
+  Defaults to the free endpoint `https://api.openweathermap.org/data/2.5/forecast`.
 
 ## Deployment
 
 Ensure `OPENWEATHER_API_KEY` is set in the environment where the backend runs.
 `OPENWEATHER_URL` may be overridden if pointing to a different OpenWeather
-instance; otherwise, it falls back to the free v2.5 endpoint listed above.
+instance; otherwise, it falls back to the free forecast endpoint listed above.

--- a/ride_aware_backend/services/weather_service.py
+++ b/ride_aware_backend/services/weather_service.py
@@ -12,7 +12,7 @@ class MissingAPIKeyError(Exception):
     """Raised when the OpenWeather API key is missing."""
 
 OPENWEATHER_URL = os.getenv(
-    "OPENWEATHER_URL", "https://api.openweathermap.org/data/2.5/onecall"
+    "OPENWEATHER_URL", "https://api.openweathermap.org/data/2.5/forecast"
 )
 logger = logging.getLogger(__name__)
 
@@ -47,34 +47,35 @@ def get_hourly_forecast(lat: float, lon: float, target_time: datetime) -> Dict:
         "lat": lat,
         "lon": lon,
         "appid": api_key,
-        "exclude": "current,minutely,daily,alerts",
+        "units": "metric",
+        "cnt": 8,
     }
     response = requests.get(OPENWEATHER_URL, params=params)
     logger.debug(
         "Weather API response status: %s", getattr(response, "status_code", "unknown")
     )
     response.raise_for_status()
-    hourly = response.json().get("hourly", [])
-    if not hourly:
-        logger.error("No hourly data available from weather service")
-        raise ValueError("No hourly data available")
+    forecast_list = response.json().get("list", [])
+    if not forecast_list:
+        logger.error("No forecast data available from weather service")
+        raise ValueError("No forecast data available")
 
     target_ts = int(target_time.timestamp())
-    closest = min(hourly, key=lambda h: abs(h.get("dt", 0) - target_ts))
+    closest = min(forecast_list, key=lambda h: abs(h.get("dt", 0) - target_ts))
+
+    rain_data = closest.get("rain")
+    if isinstance(rain_data, dict):
+        rain_data = rain_data.get("3h")
 
     data = {
-        "wind_speed": closest.get("wind_speed"),
-        "wind_deg": closest.get("wind_deg"),
-        "rain": (
-            closest.get("rain", {}).get("1h")
-            if isinstance(closest.get("rain"), dict)
-            else closest.get("rain")
-        ),
-        "humidity": closest.get("humidity"),
-        "temp": closest.get("temp"),
+        "wind_speed": closest.get("wind", {}).get("speed"),
+        "wind_deg": closest.get("wind", {}).get("deg"),
+        "rain": rain_data,
+        "humidity": closest.get("main", {}).get("humidity"),
+        "temp": closest.get("main", {}).get("temp"),
         "visibility": closest.get("visibility"),
         "uvi": closest.get("uvi"),
-        "clouds": closest.get("clouds"),
+        "clouds": closest.get("clouds", {}).get("all"),
     }
     logger.debug("Selected weather data: %s", data)
     return data

--- a/ride_aware_backend/tests/services/test_weather_service.py
+++ b/ride_aware_backend/tests/services/test_weather_service.py
@@ -17,26 +17,38 @@ def make_response(data):
 
 def test_get_hourly_forecast(monkeypatch):
     dt = datetime(2023, 1, 1, 12, 0)
-    hourly = [{"dt": int(dt.timestamp()), "wind_speed": 5}]
+    forecast_list = [{"dt": int(dt.timestamp()), "wind": {"speed": 5}}]
     monkeypatch.setenv("OPENWEATHER_API_KEY", "key")
     monkeypatch.delenv("OPENWEATHER_URL", raising=False)
     captured = {}
 
     def fake_get(url, params=None):
         captured["url"] = url
-        return make_response({"hourly": hourly})
+        captured["params"] = params
+        return make_response({"list": forecast_list})
 
     monkeypatch.setattr(weather_service.requests, "get", fake_get)
     res = weather_service.get_hourly_forecast(1.0, 2.0, dt)
     assert res["wind_speed"] == 5
-    assert captured["url"] == "https://api.openweathermap.org/data/2.5/onecall"
+    assert captured["url"] == "https://api.openweathermap.org/data/2.5/forecast"
+    assert captured["params"] == {
+        "lat": 1.0,
+        "lon": 2.0,
+        "appid": "key",
+        "units": "metric",
+        "cnt": 8,
+    }
 
 
 def test_get_hourly_forecast_no_data(monkeypatch):
     dt = datetime(2023, 1, 1, 12, 0)
     monkeypatch.setenv("OPENWEATHER_API_KEY", "key")
     monkeypatch.delenv("OPENWEATHER_URL", raising=False)
-    monkeypatch.setattr(weather_service.requests, "get", lambda url, params=None: make_response({"hourly": []}))
+    monkeypatch.setattr(
+        weather_service.requests,
+        "get",
+        lambda url, params=None: make_response({"list": []}),
+    )
     with pytest.raises(ValueError):
         weather_service.get_hourly_forecast(1.0, 2.0, dt)
 


### PR DESCRIPTION
## Summary
- switch weather service to OpenWeatherMap 5-day forecast API with metric units and 24h window
- document forecast endpoint and environment variable usage
- adjust tests for new forecast data structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec9617914832897d7b83a8aa1e61a