### PR TITLE
feat: add upcoming commute alert widget

### DIFF
--- a/ride_aware_backend/controllers/forecast_controller.py
+++ b/ride_aware_backend/controllers/forecast_controller.py
@@ -1,0 +1,10 @@
+import logging
+from datetime import datetime
+from services.weather_service import get_hourly_forecast
+
+logger = logging.getLogger(__name__)
+
+async def get_forecast(lat: float, lon: float, time: datetime) -> dict:
+    """Controller layer for single forecast snapshot."""
+    logger.info("Getting forecast for lat=%s lon=%s at %s", lat, lon, time)
+    return get_hourly_forecast(lat, lon, time)

--- a/ride_aware_backend/main.py
+++ b/ride_aware_backend/main.py
@@ -1,6 +1,6 @@
 import logging
 from fastapi import FastAPI
-from routes import thresholds, routes, fcm, commute_status
+from routes import thresholds, routes, fcm, commute_status, forecast
 
 
 logging.basicConfig(
@@ -15,3 +15,4 @@ app.include_router(thresholds.router)
 app.include_router(routes.router)
 app.include_router(fcm.router)
 app.include_router(commute_status.router)
+app.include_router(forecast.router)

--- a/ride_aware_backend/routes/forecast.py
+++ b/ride_aware_backend/routes/forecast.py
@@ -1,0 +1,21 @@
+import logging
+from datetime import datetime
+from fastapi import APIRouter, HTTPException
+from controllers.forecast_controller import get_forecast
+from services.weather_service import MissingAPIKeyError
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api", tags=["Forecast"])
+
+@router.get("/forecast")
+async def forecast(lat: float, lon: float, time: datetime):
+    """Return weather forecast snapshot for given coordinates and time."""
+    logger.info("Requesting forecast for lat=%s lon=%s at %s", lat, lon, time)
+    try:
+        return await get_forecast(lat, lon, time)
+    except MissingAPIKeyError as e:
+        logger.error("Weather service configuration error: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Unexpected error retrieving forecast")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/ride_aware_backend/tests/routes/test_forecast_route.py
+++ b/ride_aware_backend/tests/routes/test_forecast_route.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routes import forecast
+from services.weather_service import MissingAPIKeyError
+
+
+def test_forecast_success(monkeypatch):
+    async def fake_get_forecast(lat: float, lon: float, time):
+        return {"temp": 20}
+
+    monkeypatch.setattr(forecast, "get_forecast", fake_get_forecast)
+
+    app = FastAPI()
+    app.include_router(forecast.router)
+    client = TestClient(app)
+
+    resp = client.get(
+        "/api/forecast",
+        params={"lat": 1.0, "lon": 2.0, "time": "2024-01-01T08:00:00"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"temp": 20}
+
+
+def test_forecast_missing_api_key(monkeypatch):
+    async def fake_get_forecast(lat: float, lon: float, time):
+        raise MissingAPIKeyError("OPENWEATHER_API_KEY environment variable not set")
+
+    monkeypatch.setattr(forecast, "get_forecast", fake_get_forecast)
+
+    app = FastAPI()
+    app.include_router(forecast.router)
+    client = TestClient(app)
+
+    resp = client.get(
+        "/api/forecast",
+        params={"lat": 1.0, "lon": 2.0, "time": "2024-01-01T08:00:00"},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "OPENWEATHER_API_KEY environment variable not set"

--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -1,6 +1,6 @@
 import 'package:active_commuter_support/screens/preferences_screen.dart';
 import 'package:active_commuter_support/services/notification_service.dart';
-import 'package:active_commuter_support/widgets/commute_status_panel.dart';
+import 'package:active_commuter_support/widgets/upcoming_commute_alert.dart';
 import 'package:flutter/material.dart';
 
 class DashboardScreen extends StatefulWidget {
@@ -59,14 +59,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  'Here\'s your commute status for today',
+                  'Plan ahead for your next ride',
                   style: TextStyle(fontSize: 16, color: Colors.grey),
                 ),
               ),
             ),
 
             // Commute Status Panel
-            const CommuteStatusPanel(),
+            const UpcomingCommuteAlert(),
 
             // Notification Status Card
             Card(

--- a/ride_aware_frontend/lib/services/forecast_service.dart
+++ b/ride_aware_frontend/lib/services/forecast_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart';
+import 'device_id_service.dart';
+import 'api_service.dart';
+
+class ForecastService {
+  final DeviceIdService _deviceIdService = DeviceIdService();
+
+  Future<Map<String, dynamic>> getForecast(
+      double lat, double lon, DateTime time) async {
+    final uri = Uri.parse('${ApiService.baseUrl}/api/forecast').replace(
+      queryParameters: {
+        'lat': lat.toString(),
+        'lon': lon.toString(),
+        'time': time.toIso8601String(),
+      },
+    );
+
+    final response = await http.get(uri, headers: await _getHeaders());
+
+    if (kDebugMode) {
+      print('📡 Forecast API Response: ${response.statusCode}');
+      if (response.body.isNotEmpty) {
+        print('   Response Body: ${response.body}');
+      }
+    }
+
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else {
+      throw Exception('Failed to load forecast: ${response.statusCode}');
+    }
+  }
+
+  Future<Map<String, String>> _getHeaders() async {
+    final deviceId = await _deviceIdService.getParticipantIdHash();
+    return {
+      'Content-Type': 'application/json',
+      'X-Device-Id': deviceId ?? 'unknown',
+    };
+  }
+}

--- a/ride_aware_frontend/lib/services/user_route_service.dart
+++ b/ride_aware_frontend/lib/services/user_route_service.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart';
+import '../models/route_model.dart';
+import 'device_id_service.dart';
+import 'api_service.dart';
+
+class UserRouteService {
+  final DeviceIdService _deviceIdService = DeviceIdService();
+
+  Future<RouteModel?> fetchRoute() async {
+    final deviceId = await _deviceIdService.getParticipantIdHash();
+    if (deviceId == null) {
+      return null;
+    }
+
+    final uri = Uri.parse('${ApiService.baseUrl}/routes/$deviceId');
+    final response = await http.get(uri, headers: await _getHeaders());
+
+    if (kDebugMode) {
+      print('📡 Route Fetch Response: ${response.statusCode}');
+    }
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      return RouteModel.fromJson(data);
+    } else {
+      return null;
+    }
+  }
+
+  Future<Map<String, String>> _getHeaders() async {
+    final deviceId = await _deviceIdService.getParticipantIdHash();
+    return {
+      'Content-Type': 'application/json',
+      'X-Device-Id': deviceId ?? 'unknown',
+    };
+  }
+}

--- a/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
+++ b/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
@@ -1,0 +1,184 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import '../models/user_preferences.dart';
+import '../models/route_model.dart';
+import '../models/geo_point.dart';
+import '../services/preferences_service.dart';
+import '../services/forecast_service.dart';
+import '../services/user_route_service.dart';
+
+class CommuteAlertResult {
+  final DateTime time;
+  final WeatherLimits limits;
+  final RouteModel route;
+  final Map<String, dynamic> forecast;
+  final String status; // ok, warning, alert
+  final List<String> issues;
+  final List<String> borderline;
+
+  CommuteAlertResult({
+    required this.time,
+    required this.limits,
+    required this.route,
+    required this.forecast,
+    required this.status,
+    required this.issues,
+    required this.borderline,
+  });
+}
+
+class UpcomingCommuteViewModel extends ChangeNotifier {
+  final PreferencesService _prefsService = PreferencesService();
+  final ForecastService _forecastService = ForecastService();
+  final UserRouteService _routeService = UserRouteService();
+
+  bool isLoading = false;
+  String? error;
+  bool needsCommuteTime = false;
+  CommuteAlertResult? result;
+
+  Future<void> load() async {
+    isLoading = true;
+    error = null;
+    needsCommuteTime = false;
+    notifyListeners();
+
+    try {
+      final prefsSet = await _prefsService.arePreferencesSet();
+      if (!prefsSet) {
+        needsCommuteTime = true;
+        return;
+      }
+      final prefs = await _prefsService.loadPreferences();
+      final route = await _routeService.fetchRoute();
+      if (route == null) {
+        error = 'No route saved';
+        return;
+      }
+
+      final DateTime targetTime = _nextCommuteTime(prefs);
+      final forecast = await _forecastService.getForecast(
+          route.startLocation.latitude,
+          route.startLocation.longitude,
+          targetTime);
+      final evaluation = _evaluate(forecast, prefs.weatherLimits, route);
+      forecast['headwind'] = evaluation['headwind'];
+      forecast['crosswind'] = evaluation['crosswind'];
+      result = CommuteAlertResult(
+        time: targetTime,
+        limits: prefs.weatherLimits,
+        route: route,
+        forecast: forecast,
+        status: evaluation['status'] as String,
+        issues: List<String>.from(evaluation['issues'] as List),
+        borderline: List<String>.from(evaluation['borderline'] as List),
+      );
+    } catch (e) {
+      error = e.toString();
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  DateTime _nextCommuteTime(UserPreferences prefs) {
+    final now = DateTime.now();
+    TimeOfDay rideTime = prefs.commuteWindows.morningLocal;
+    DateTime scheduled = DateTime(
+      now.year,
+      now.month,
+      now.day + 1,
+      rideTime.hour,
+      rideTime.minute,
+    );
+    return scheduled;
+  }
+
+  Map<String, dynamic> _evaluate(
+      Map<String, dynamic> forecast, WeatherLimits limits, RouteModel route) {
+    final List<String> issues = [];
+    final List<String> borderline = [];
+
+    double wind = (forecast['wind_speed'] ?? 0).toDouble();
+    double rain = (forecast['rain'] ?? 0).toDouble();
+    double humidity = (forecast['humidity'] ?? 0).toDouble();
+    double temp = (forecast['temp'] ?? 0).toDouble();
+    double windDeg = (forecast['wind_deg'] ?? 0).toDouble();
+
+    if (wind > limits.maxWindSpeed) {
+      issues.add('Wind speed > ${limits.maxWindSpeed} m/s');
+    } else if (wind > limits.maxWindSpeed * 0.8) {
+      borderline.add('Wind speed near limit');
+    }
+
+    if (rain > limits.maxRainIntensity) {
+      issues.add('Rain > ${limits.maxRainIntensity} mm');
+    } else if (rain > limits.maxRainIntensity * 0.8) {
+      borderline.add('Rain near limit');
+    }
+
+    if (humidity > limits.maxHumidity) {
+      issues.add('Humidity > ${limits.maxHumidity}%');
+    }
+
+    if (temp < limits.minTemperature || temp > limits.maxTemperature) {
+      issues.add(
+          'Temperature outside ${limits.minTemperature}-${limits.maxTemperature}°C');
+    } else if (temp < limits.minTemperature + 2 ||
+        temp > limits.maxTemperature - 2) {
+      borderline.add('Temperature near limit');
+    }
+
+    // Headwind and crosswind evaluation
+    final bearing = _bearing(route.startLocation, route.endLocation);
+    final rel = ((windDeg - bearing) + 360) % 360;
+    final head = wind * math.cos(rel * math.pi / 180);
+    final cross = wind * math.sin(rel * math.pi / 180);
+
+    if (head.abs() > limits.headwindSensitivity) {
+      issues.add('Headwind > ${limits.headwindSensitivity} m/s');
+    } else if (head.abs() > limits.headwindSensitivity * 0.8) {
+      borderline.add('Headwind near limit');
+    }
+
+    if (cross.abs() > limits.crosswindSensitivity) {
+      issues.add('Crosswind > ${limits.crosswindSensitivity} m/s');
+    } else if (cross.abs() > limits.crosswindSensitivity * 0.8) {
+      borderline.add('Crosswind near limit');
+    }
+
+    final status = issues.isNotEmpty
+        ? 'alert'
+        : (borderline.isNotEmpty ? 'warning' : 'ok');
+
+    return {
+      'status': status,
+      'issues': issues,
+      'borderline': borderline,
+      'headwind': head.abs(),
+      'crosswind': cross.abs(),
+    };
+  }
+
+  double _bearing(GeoPoint a, GeoPoint b) {
+    final lat1 = a.latitude * math.pi / 180;
+    final lat2 = b.latitude * math.pi / 180;
+    final dLon = (b.longitude - a.longitude) * math.pi / 180;
+    final y = math.sin(dLon) * math.cos(lat2);
+    final x = math.cos(lat1) * math.sin(lat2) -
+        math.sin(lat1) * math.cos(lat2) * math.cos(dLon);
+    final brng = math.atan2(y, x) * 180 / math.pi;
+    return (brng + 360) % 360;
+  }
+
+  Future<void> setCommuteTime(TimeOfDay time) async {
+    final prefs = await _prefsService.loadPreferences();
+    final updated = prefs.copyWith(
+      commuteWindows: prefs.commuteWindows.copyWith(
+        morning: CommuteWindows.localTimeOfDayToUtc(time),
+      ),
+    );
+    await _prefsService.savePreferences(updated);
+    await load();
+  }
+}

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import '../viewmodels/upcoming_commute_view_model.dart';
+
+class UpcomingCommuteAlert extends StatefulWidget {
+  const UpcomingCommuteAlert({super.key});
+
+  @override
+  State<UpcomingCommuteAlert> createState() => _UpcomingCommuteAlertState();
+}
+
+class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
+  final UpcomingCommuteViewModel _vm = UpcomingCommuteViewModel();
+
+  @override
+  void initState() {
+    super.initState();
+    _vm.addListener(_onUpdate);
+    _vm.load();
+  }
+
+  void _onUpdate() => setState(() {});
+
+  @override
+  void dispose() {
+    _vm.removeListener(_onUpdate);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (_vm.needsCommuteTime) {
+      return _buildSetTimeCard(theme);
+    }
+    if (_vm.isLoading) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+    if (_vm.error != null) {
+      return Card(
+        margin: const EdgeInsets.all(16),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text('Error: ${_vm.error}'),
+        ),
+      );
+    }
+    final result = _vm.result!;
+    final limits = result.limits;
+    final color = result.status == 'alert'
+        ? Colors.red
+        : result.status == 'warning'
+            ? Colors.amber
+            : Colors.green;
+    final icon = result.status == 'alert'
+        ? Icons.error
+        : result.status == 'warning'
+            ? Icons.warning
+            : Icons.check_circle;
+    return Card(
+      margin: const EdgeInsets.all(16),
+      color: color.withOpacity(0.1),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: color),
+                const SizedBox(width: 8),
+                Text('Upcoming Commute Alert',
+                    style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold, color: color)),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Next ride: ${_formatDateTime(result.time)}, Route: ${result.route.routeName}',
+              style: theme.textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            _metricRow('Temperature',
+                '${result.forecast['temp']}°C',
+                'range ${limits.minTemperature}-${limits.maxTemperature}°C'),
+            _metricRow('Wind speed',
+                '${result.forecast['wind_speed']} m/s',
+                'max ${limits.maxWindSpeed} m/s'),
+            _metricRow('Headwind',
+                '${(result.forecast['headwind'] as num).toStringAsFixed(1)} m/s',
+                'max ${limits.headwindSensitivity} m/s'),
+            _metricRow('Crosswind',
+                '${(result.forecast['crosswind'] as num).toStringAsFixed(1)} m/s',
+                'max ${limits.crosswindSensitivity} m/s'),
+            _metricRow('Rain',
+                '${result.forecast['rain'] ?? 0} mm',
+                'max ${limits.maxRainIntensity} mm'),
+            _metricRow('Humidity',
+                '${result.forecast['humidity']}%',
+                'max ${limits.maxHumidity}%'),
+            if (result.issues.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: _issuesSection(result, color, theme),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _issuesSection(
+      CommuteAlertResult result, Color color, ThemeData theme) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withOpacity(0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.warning_amber, size: 16, color: color),
+              const SizedBox(width: 6),
+              Text('Issues',
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(color: color, fontWeight: FontWeight.w600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          ...result.issues
+              .map((e) => Padding(
+                    padding: const EdgeInsets.only(bottom: 2),
+                    child: Text('• $e',
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(color: color)),
+                  ))
+              .toList(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSetTimeCard(ThemeData theme) {
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('No commute time set'),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _pickTime,
+              child: const Text('Set Ride Time'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: const TimeOfDay(hour: 8, minute: 0),
+    );
+    if (picked != null) {
+      await _vm.setCommuteTime(picked);
+    }
+  }
+
+  String _formatDateTime(DateTime dt) {
+    const days = [
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday'
+    ];
+    final day = days[dt.weekday - 1];
+    final hour = dt.hour % 12 == 0 ? 12 : dt.hour % 12;
+    final minute = dt.minute.toString().padLeft(2, '0');
+    final ampm = dt.hour >= 12 ? 'PM' : 'AM';
+    return '$day $hour:$minute $ampm';
+  }
+
+  Widget _metricRow(String label, String value, String threshold) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: theme.textTheme.bodySmall),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(value,
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.bold)),
+              Text(threshold,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontSize: 10)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- expose `/api/forecast` endpoint in backend and cover with tests
- show "Upcoming Commute Alert" panel that evaluates all weather thresholds
- replace dashboard commute status with forecast-based alert

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1f3e73c8328a978e959ae4fef75