### PR TITLE
Handle numeric strings in JSON parsing

### DIFF
--- a/ride_aware_frontend/lib/models/commute_status.dart
+++ b/ride_aware_frontend/lib/models/commute_status.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/parsing.dart';
 
 enum CommuteStatusLevel { safe, caution, unsafe }
 
@@ -133,10 +134,10 @@ class ForecastData {
 
   factory ForecastData.fromJson(Map<String, dynamic> json) {
     return ForecastData(
-      temperature: (json['temperature'] as num).toDouble(),
-      windSpeed: (json['wind_speed'] as num).toDouble(),
-      rain: (json['rain'] as num).toDouble(),
-      humidity: (json['humidity'] as num).toDouble(), // Parse humidity
+      temperature: parseDouble(json['temperature']),
+      windSpeed: parseDouble(json['wind_speed']),
+      rain: parseDouble(json['rain']),
+      humidity: parseDouble(json['humidity']),
       confidence: json['confidence'] as String,
     );
   }
@@ -157,12 +158,10 @@ class ThresholdData {
 
   factory ThresholdData.fromJson(Map<String, dynamic> json) {
     return ThresholdData(
-      windSpeed: (json['wind_speed'] as num).toDouble(),
-      rain: (json['rain'] as num).toDouble(),
-      temperatureMin: (json['temperature_min'] as num)
-          .toDouble(), // Parse temperature_min
-      temperatureMax: (json['temperature_max'] as num)
-          .toDouble(), // Parse temperature_max
+      windSpeed: parseDouble(json['wind_speed']),
+      rain: parseDouble(json['rain']),
+      temperatureMin: parseDouble(json['temperature_min']),
+      temperatureMax: parseDouble(json['temperature_max']),
     );
   }
 }

--- a/ride_aware_frontend/lib/models/geo_point.dart
+++ b/ride_aware_frontend/lib/models/geo_point.dart
@@ -1,3 +1,5 @@
+import '../utils/parsing.dart';
+
 class GeoPoint {
   final double latitude;
   final double longitude;
@@ -10,9 +12,9 @@ class GeoPoint {
   };
 
   factory GeoPoint.fromJson(Map<String, dynamic> json) => GeoPoint(
-    latitude: (json['latitude'] as num).toDouble(),
-    longitude: (json['longitude'] as num).toDouble(),
-  );
+        latitude: parseDouble(json['latitude']),
+        longitude: parseDouble(json['longitude']),
+      );
 
   @override
   bool operator ==(Object other) {

--- a/ride_aware_frontend/lib/models/user_preferences.dart
+++ b/ride_aware_frontend/lib/models/user_preferences.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/parsing.dart';
 
 class UserPreferences {
   final WeatherLimits weatherLimits;
@@ -125,15 +126,17 @@ class WeatherLimits {
 
   factory WeatherLimits.fromJson(Map<String, dynamic> json) {
     return WeatherLimits(
-      maxWindSpeed: (json['max_wind_speed'] ?? 30.0).toDouble(),
-      maxRainIntensity: (json['max_rain_intensity'] ?? 0.5).toDouble(),
-      maxHumidity: (json['max_humidity'] ?? 85.0).toDouble(),
-      minTemperature: (json['min_temperature'] ?? 5.0).toDouble(),
-      maxTemperature: (json['max_temperature'] ?? 32.0).toDouble(),
+      maxWindSpeed: parseDouble(json['max_wind_speed'], defaultValue: 30.0),
+      maxRainIntensity:
+          parseDouble(json['max_rain_intensity'], defaultValue: 0.5),
+      maxHumidity: parseDouble(json['max_humidity'], defaultValue: 85.0),
+      minTemperature: parseDouble(json['min_temperature'], defaultValue: 5.0),
+      maxTemperature:
+          parseDouble(json['max_temperature'], defaultValue: 32.0),
       headwindSensitivity:
-          (json['headwind_sensitivity'] ?? 20.0).toDouble(),
+          parseDouble(json['headwind_sensitivity'], defaultValue: 20.0),
       crosswindSensitivity:
-          (json['crosswind_sensitivity'] ?? 15.0).toDouble(),
+          parseDouble(json['crosswind_sensitivity'], defaultValue: 15.0),
     );
   }
 
@@ -241,9 +244,11 @@ class EnvironmentalRisk {
 
   factory EnvironmentalRisk.fromJson(Map<String, dynamic> json) {
     return EnvironmentalRisk(
-      minVisibility: (json['min_visibility'] ?? 1000.0).toDouble(),
-      maxPollution: (json['max_pollution'] ?? 80.0).toDouble(),
-      maxUvIndex: (json['max_uv_index'] ?? 5.0).toDouble(),
+      minVisibility:
+          parseDouble(json['min_visibility'], defaultValue: 1000.0),
+      maxPollution:
+          parseDouble(json['max_pollution'], defaultValue: 80.0),
+      maxUvIndex: parseDouble(json['max_uv_index'], defaultValue: 5.0),
     );
   }
 
@@ -308,8 +313,8 @@ class OfficeLocation {
 
   factory OfficeLocation.fromJson(Map<String, dynamic> json) {
     return OfficeLocation(
-      latitude: (json['latitude'] ?? 0.0).toDouble(),
-      longitude: (json['longitude'] ?? 0.0).toDouble(),
+      latitude: parseDouble(json['latitude']),
+      longitude: parseDouble(json['longitude']),
     );
   }
 

--- a/ride_aware_frontend/lib/services/routing_service.dart
+++ b/ride_aware_frontend/lib/services/routing_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart'; // For kDebugMode
 import '../models/geo_point.dart';
+import '../utils/parsing.dart';
 
 class RoutingService {
   // IMPORTANT: Replace with your actual OpenRouteService API Key
@@ -66,8 +67,8 @@ class RoutingService {
         // OpenRouteService returns [longitude, latitude]
         final routePoints = coordinatesList.map((coord) {
           return GeoPoint(
-            latitude: coord[1].toDouble(),
-            longitude: coord[0].toDouble(),
+            latitude: parseDouble(coord[1]),
+            longitude: parseDouble(coord[0]),
           );
         }).toList();
 

--- a/ride_aware_frontend/lib/utils/parsing.dart
+++ b/ride_aware_frontend/lib/utils/parsing.dart
@@ -1,0 +1,6 @@
+ double parseDouble(dynamic value, {double defaultValue = 0.0}) {
+   if (value == null) return defaultValue;
+   if (value is num) return value.toDouble();
+   if (value is String) return double.tryParse(value) ?? defaultValue;
+   return defaultValue;
+ }

--- a/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
+++ b/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
@@ -6,6 +6,7 @@ import '../models/geo_point.dart';
 import '../services/preferences_service.dart';
 import '../services/forecast_service.dart';
 import '../services/user_route_service.dart';
+import '../utils/parsing.dart';
 
 class CommuteAlertResult {
   final DateTime time;
@@ -99,11 +100,11 @@ class UpcomingCommuteViewModel extends ChangeNotifier {
     final List<String> issues = [];
     final List<String> borderline = [];
 
-    double wind = (forecast['wind_speed'] ?? 0).toDouble();
-    double rain = (forecast['rain'] ?? 0).toDouble();
-    double humidity = (forecast['humidity'] ?? 0).toDouble();
-    double temp = (forecast['temp'] ?? 0).toDouble();
-    double windDeg = (forecast['wind_deg'] ?? 0).toDouble();
+    double wind = parseDouble(forecast['wind_speed']);
+    double rain = parseDouble(forecast['rain']);
+    double humidity = parseDouble(forecast['humidity']);
+    double temp = parseDouble(forecast['temp']);
+    double windDeg = parseDouble(forecast['wind_deg']);
 
     if (wind > limits.maxWindSpeed) {
       issues.add('Wind speed > ${limits.maxWindSpeed} m/s');

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../viewmodels/upcoming_commute_view_model.dart';
+import '../utils/parsing.dart';
 
 class UpcomingCommuteAlert extends StatefulWidget {
   const UpcomingCommuteAlert({super.key});
@@ -61,6 +62,8 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
         : result.status == 'warning'
             ? Icons.warning
             : Icons.check_circle;
+    final headwind = parseDouble(result.forecast['headwind']);
+    final crosswind = parseDouble(result.forecast['crosswind']);
     return Card(
       margin: const EdgeInsets.all(16),
       color: color.withOpacity(0.1),
@@ -91,10 +94,10 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
                 '${result.forecast['wind_speed']} m/s',
                 'max ${limits.maxWindSpeed} m/s'),
             _metricRow('Headwind',
-                '${(result.forecast['headwind'] as num).toStringAsFixed(1)} m/s',
+                '${headwind.toStringAsFixed(1)} m/s',
                 'max ${limits.headwindSensitivity} m/s'),
             _metricRow('Crosswind',
-                '${(result.forecast['crosswind'] as num).toStringAsFixed(1)} m/s',
+                '${crosswind.toStringAsFixed(1)} m/s',
                 'max ${limits.crosswindSensitivity} m/s'),
             _metricRow('Rain',
                 '${result.forecast['rain'] ?? 0} mm',


### PR DESCRIPTION
## Summary
- Add `parseDouble` utility to safely convert dynamic or string values to doubles.
- Replace direct numeric casts across models, services, and widgets with `parseDouble` for resilience to stringified numbers.
- Display headwind and crosswind values safely in `UpcomingCommuteAlert`.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689014dc2a5c832897a9256f917f9cd8