### PR TITLE
Parse forecast numeric values

### DIFF
--- a/ride_aware_frontend/pubspec.yaml
+++ b/ride_aware_frontend/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  test: ^1.24.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/ride_aware_frontend/test/forecast_service_test.dart
+++ b/ride_aware_frontend/test/forecast_service_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:active_commuter_support/services/forecast_service.dart';
+import 'package:active_commuter_support/services/device_id_service.dart';
+
+class _FakeDeviceIdService extends DeviceIdService {
+  @override
+  Future<String?> getParticipantIdHash() async => 'test-device';
+}
+
+void main() {
+  test('getForecast parses numeric strings to doubles', () async {
+    final mockResponse = {
+      'wind_speed': '5.5',
+      'wind_deg': '180',
+      'rain': '0.1',
+      'humidity': '70',
+      'temp': '15',
+      'visibility': '10000',
+      'uvi': '3',
+      'clouds': '75',
+    };
+
+    final mockClient = MockClient((request) async {
+      return http.Response(jsonEncode(mockResponse), 200);
+    });
+
+    final service = ForecastService(
+      client: mockClient,
+      deviceIdService: _FakeDeviceIdService(),
+    );
+
+    final result = await service.getForecast(0, 0, DateTime.now());
+
+    expect(result['wind_speed'], isA<double>());
+    expect(result['wind_deg'], isA<double>());
+    expect(result['rain'], isA<double>());
+    expect(result['humidity'], isA<double>());
+    expect(result['temp'], isA<double>());
+    expect(result['visibility'], isA<double>());
+    expect(result['uvi'], isA<double>());
+    expect(result['clouds'], isA<double>());
+  });
+}


### PR DESCRIPTION
## Summary
- ensure forecast service uses `parseDouble` for numeric weather fields
- add unit test verifying stringified numbers are parsed to doubles

## Testing
- `dart test ride_aware_frontend/test/forecast_service_test.dart` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_6890e630b2148328852ffbd1fdee7303