### PR TITLE
feat: add route-aware weather evaluation

### DIFF
--- a/ride_aware_backend/controllers/forecast_controller.py
+++ b/ride_aware_backend/controllers/forecast_controller.py
@@ -1,6 +1,9 @@
 import logging
 from datetime import datetime
+from typing import List, Dict
 from services.weather_service import get_hourly_forecast
+from services.route_weather_service import evaluate_route_weather
+from models.thresholds import WeatherLimits
 
 logger = logging.getLogger(__name__)
 
@@ -8,3 +11,11 @@ async def get_forecast(lat: float, lon: float, time: datetime) -> dict:
     """Controller layer for single forecast snapshot."""
     logger.info("Getting forecast for lat=%s lon=%s at %s", lat, lon, time)
     return get_hourly_forecast(lat, lon, time)
+
+
+async def evaluate_route(
+    points: List[Dict[str, float]], time: datetime, thresholds: WeatherLimits
+) -> dict:
+    """Controller layer for route-wide weather evaluation."""
+    logger.info("Evaluating route with %s points at %s", len(points), time)
+    return evaluate_route_weather(points, time, thresholds)

--- a/ride_aware_backend/routes/forecast.py
+++ b/ride_aware_backend/routes/forecast.py
@@ -1,8 +1,11 @@
 import logging
 from datetime import datetime
 from fastapi import APIRouter, HTTPException
-from controllers.forecast_controller import get_forecast
+from pydantic import BaseModel
+from typing import List
+from controllers.forecast_controller import get_forecast, evaluate_route
 from services.weather_service import MissingAPIKeyError
+from models.thresholds import WeatherLimits
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["Forecast"])
@@ -18,4 +21,30 @@ async def forecast(lat: float, lon: float, time: datetime):
         raise HTTPException(status_code=500, detail=str(e))
     except Exception:
         logger.exception("Unexpected error retrieving forecast")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+class _Point(BaseModel):
+    latitude: float
+    longitude: float
+
+
+class RouteForecastRequest(BaseModel):
+    points: List[_Point]
+    time: datetime
+    thresholds: WeatherLimits
+
+
+@router.post("/forecast/route")
+async def forecast_route(req: RouteForecastRequest):
+    """Evaluate weather along a route of points."""
+    logger.info("Route forecast request with %s points", len(req.points))
+    try:
+        pts = [p.dict() for p in req.points]
+        return await evaluate_route(pts, req.time, req.thresholds)
+    except MissingAPIKeyError as e:
+        logger.error("Weather service configuration error: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Unexpected error retrieving route forecast")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/ride_aware_backend/services/commute_evaluator.py
+++ b/ride_aware_backend/services/commute_evaluator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import List, Dict
+import math
 
 from models.thresholds import WeatherLimits
 
@@ -10,57 +11,154 @@ logger = logging.getLogger(__name__)
 
 
 def evaluate_thresholds(weather_data: dict, thresholds: WeatherLimits) -> List[str]:
-    """Compare weather data against user thresholds.
+    """Return only exceeded threshold messages for backwards compatibility."""
+    return evaluate_detailed_thresholds(weather_data, thresholds)["issues"]
 
-    Returns a list of messages for each exceeded threshold."""
-    messages: List[str] = []
-    if (
-        thresholds.max_wind_speed is not None
-        and weather_data.get("wind_speed") is not None
-        and weather_data["wind_speed"] > thresholds.max_wind_speed
-    ):
-        messages.append("Wind speed exceeds your comfort limit")
 
-    rain = weather_data.get("rain") or 0
-    if thresholds.max_rain_intensity is not None and rain > thresholds.max_rain_intensity:
-        messages.append("Rain intensity exceeds your comfort limit")
+def evaluate_detailed_thresholds(
+    weather_data: Dict, thresholds: WeatherLimits, route_bearing: float | None = None
+) -> Dict[str, List[str] | float | None]:
+    """Compare weather data against user thresholds with borderline and wind context.
 
-    if (
-        thresholds.max_humidity is not None
-        and weather_data.get("humidity") is not None
-        and weather_data["humidity"] > thresholds.max_humidity
-    ):
-        messages.append("Humidity exceeds your comfort limit")
+    Parameters
+    ----------
+    weather_data: dict
+        Snapshot of weather metrics.
+    thresholds: WeatherLimits
+        User defined limits.
+    route_bearing: float, optional
+        Bearing of the route (degrees) for head/cross wind calculation.
 
+    Returns
+    -------
+    dict
+        Dictionary containing ``issues`` and ``borderline`` lists along with
+        calculated ``headwind`` and ``crosswind`` values when bearing and wind
+        direction are available.
+    """
+    issues: List[str] = []
+    borderline: List[str] = []
+
+    wind = float(weather_data.get("wind_speed") or 0)
+    rain = float(weather_data.get("rain") or 0)
+    humidity = float(weather_data.get("humidity") or 0)
     temp = weather_data.get("temp")
+    wind_deg = weather_data.get("wind_deg")
+
+    max_wind_speed = (
+        float(thresholds.max_wind_speed) if thresholds.max_wind_speed is not None else None
+    )
+    max_rain_intensity = (
+        float(thresholds.max_rain_intensity)
+        if thresholds.max_rain_intensity is not None
+        else None
+    )
+    max_humidity = (
+        float(thresholds.max_humidity) if thresholds.max_humidity is not None else None
+    )
+    min_temperature = (
+        float(thresholds.min_temperature)
+        if thresholds.min_temperature is not None
+        else None
+    )
+    max_temperature = (
+        float(thresholds.max_temperature)
+        if thresholds.max_temperature is not None
+        else None
+    )
+    headwind_sens = (
+        float(thresholds.headwind_sensitivity)
+        if thresholds.headwind_sensitivity is not None
+        else None
+    )
+    crosswind_sens = (
+        float(thresholds.crosswind_sensitivity)
+        if thresholds.crosswind_sensitivity is not None
+        else None
+    )
+
+    min_visibility = (
+        float(thresholds.min_visibility)
+        if thresholds.min_visibility is not None
+        else None
+    )
+    max_uv_index = (
+        float(thresholds.max_uv_index) if thresholds.max_uv_index is not None else None
+    )
+    max_pollution = (
+        float(thresholds.max_pollution)
+        if thresholds.max_pollution is not None
+        else None
+    )
+
+    if max_wind_speed is not None:
+        if wind > max_wind_speed:
+            issues.append("Wind speed exceeds your comfort limit")
+        elif wind > max_wind_speed * 0.8:
+            borderline.append("Wind speed near limit")
+
+    if max_rain_intensity is not None:
+        if rain > max_rain_intensity:
+            issues.append("Rain intensity exceeds your comfort limit")
+        elif rain > max_rain_intensity * 0.8:
+            borderline.append("Rain near limit")
+
+    if max_humidity is not None and humidity > max_humidity:
+        issues.append("Humidity exceeds your comfort limit")
+
     if temp is not None:
-        if thresholds.min_temperature is not None and temp < thresholds.min_temperature:
-            messages.append("Temperature is below your comfort range")
-        if thresholds.max_temperature is not None and temp > thresholds.max_temperature:
-            messages.append("Temperature is above your comfort range")
+        temp = float(temp)
+        if min_temperature is not None and temp < min_temperature:
+            issues.append("Temperature is below your comfort range")
+        elif min_temperature is not None and temp < min_temperature + 2:
+            borderline.append("Temperature near limit")
+        if max_temperature is not None and temp > max_temperature:
+            issues.append("Temperature is above your comfort range")
+        elif max_temperature is not None and temp > max_temperature - 2:
+            if "Temperature near limit" not in borderline:
+                borderline.append("Temperature near limit")
 
     if (
-        thresholds.min_visibility is not None
+        min_visibility is not None
         and weather_data.get("visibility") is not None
-        and weather_data["visibility"] < thresholds.min_visibility
+        and weather_data["visibility"] < min_visibility
     ):
-        messages.append("Visibility is below your comfort limit")
+        issues.append("Visibility is below your comfort limit")
 
     if (
-        thresholds.max_uv_index is not None
+        max_uv_index is not None
         and weather_data.get("uvi") is not None
-        and weather_data["uvi"] > thresholds.max_uv_index
+        and weather_data["uvi"] > max_uv_index
     ):
-        messages.append("UV index exceeds your comfort limit")
+        issues.append("UV index exceeds your comfort limit")
 
     pollution = weather_data.get("pollution")
-    if (
-        thresholds.max_pollution is not None
-        and pollution is not None
-        and pollution > thresholds.max_pollution
-    ):
-        messages.append("Pollution exceeds your comfort limit")
+    if max_pollution is not None and pollution is not None and pollution > max_pollution:
+        issues.append("Pollution exceeds your comfort limit")
 
-    logger.debug("Threshold evaluation messages: %s", messages)
-    return messages
+    head = cross = None
+    if wind_deg is not None and route_bearing is not None:
+        rel = ((float(wind_deg) - route_bearing) + 360) % 360
+        head = wind * math.cos(math.radians(rel))
+        cross = wind * math.sin(math.radians(rel))
+
+        if headwind_sens is not None:
+            if abs(head) > headwind_sens:
+                issues.append("Headwind exceeds your comfort limit")
+            elif abs(head) > headwind_sens * 0.8:
+                borderline.append("Headwind near limit")
+
+        if crosswind_sens is not None:
+            if abs(cross) > crosswind_sens:
+                issues.append("Crosswind exceeds your comfort limit")
+            elif abs(cross) > crosswind_sens * 0.8:
+                borderline.append("Crosswind near limit")
+
+    logger.debug("Detailed threshold evaluation issues=%s borderline=%s", issues, borderline)
+    return {
+        "issues": issues,
+        "borderline": borderline,
+        "headwind": abs(head) if head is not None else None,
+        "crosswind": abs(cross) if cross is not None else None,
+    }
 

--- a/ride_aware_backend/services/route_weather_service.py
+++ b/ride_aware_backend/services/route_weather_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import List, Dict, Any
+
+from models.thresholds import WeatherLimits
+from services.weather_service import get_hourly_forecast
+from services.commute_evaluator import evaluate_detailed_thresholds
+
+logger = logging.getLogger(__name__)
+
+
+def _bearing(a: Dict[str, float], b: Dict[str, float]) -> float:
+    """Calculate bearing from point a to b in degrees."""
+    import math
+
+    lat1 = math.radians(a["latitude"])
+    lat2 = math.radians(b["latitude"])
+    dlon = math.radians(b["longitude"] - a["longitude"])
+    y = math.sin(dlon) * math.cos(lat2)
+    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(dlon)
+    brng = math.degrees(math.atan2(y, x))
+    return (brng + 360) % 360
+
+
+def evaluate_route_weather(
+    points: List[Dict[str, float]], time: datetime, thresholds: WeatherLimits
+) -> Dict[str, Any]:
+    """Fetch weather for multiple route points and evaluate against thresholds.
+
+    Parameters
+    ----------
+    points: list of dict
+        Sequence of coordinates with keys ``latitude`` and ``longitude``.
+    time: datetime
+        Scheduled commute time.
+    thresholds: WeatherLimits
+        User-defined comfort limits.
+    """
+    if not points:
+        raise ValueError("At least one route point is required")
+
+    route_bearing = _bearing(points[0], points[-1]) if len(points) > 1 else None
+    results: List[Dict[str, Any]] = []
+    overall_issues: set[str] = set()
+    overall_borderline: set[str] = set()
+
+    max_values: Dict[str, float] = {
+        "wind_speed": 0.0,
+        "rain": 0.0,
+        "humidity": 0.0,
+        "headwind": 0.0,
+        "crosswind": 0.0,
+        "temp_max": float("-inf"),
+        "temp_min": float("inf"),
+    }
+
+    for idx, pt in enumerate(points):
+        logger.debug("Fetching weather for point %s: %s", idx, pt)
+        weather = get_hourly_forecast(pt["latitude"], pt["longitude"], time)
+        detailed = evaluate_detailed_thresholds(weather, thresholds, route_bearing)
+
+        # Track maxima/minima for summary
+        wind = weather.get("wind_speed") or 0
+        rain = weather.get("rain") or 0
+        humidity = weather.get("humidity") or 0
+        temp = weather.get("temp")
+        head = detailed.get("headwind") or 0
+        cross = detailed.get("crosswind") or 0
+
+        max_values["wind_speed"] = max(max_values["wind_speed"], wind)
+        max_values["rain"] = max(max_values["rain"], rain)
+        max_values["humidity"] = max(max_values["humidity"], humidity)
+        max_values["headwind"] = max(max_values["headwind"], head)
+        max_values["crosswind"] = max(max_values["crosswind"], cross)
+        if temp is not None:
+            max_values["temp_max"] = max(max_values["temp_max"], temp)
+            max_values["temp_min"] = min(max_values["temp_min"], temp)
+
+        overall_issues.update(detailed["issues"])
+        overall_borderline.update(detailed["borderline"])
+
+        results.append(
+            {
+                "index": idx,
+                "location": pt,
+                "weather": weather,
+                "issues": detailed["issues"],
+                "borderline": detailed["borderline"],
+                "headwind": detailed["headwind"],
+                "crosswind": detailed["crosswind"],
+            }
+        )
+
+    status = "alert" if overall_issues else ("warning" if overall_borderline else "ok")
+    summary = {
+        "max_wind_speed": max_values["wind_speed"],
+        "max_rain": max_values["rain"],
+        "max_humidity": max_values["humidity"],
+        "max_headwind": max_values["headwind"],
+        "max_crosswind": max_values["crosswind"],
+        "min_temp": max_values["temp_min"],
+        "max_temp": max_values["temp_max"],
+    }
+
+    return {
+        "status": status,
+        "issues": list(overall_issues),
+        "borderline": list(overall_borderline),
+        "summary": summary,
+        "points": results,
+    }

--- a/ride_aware_frontend/lib/services/forecast_service.dart
+++ b/ride_aware_frontend/lib/services/forecast_service.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import '../utils/parsing.dart';
 import 'device_id_service.dart';
 import 'api_service.dart';
+import '../models/geo_point.dart';
+import '../models/user_preferences.dart';
 
 class ForecastService {
   final DeviceIdService _deviceIdService;
@@ -55,6 +57,30 @@ class ForecastService {
       return data;
     } else {
       throw Exception('Failed to load forecast: ${response.statusCode}');
+    }
+  }
+
+  /// Evaluate weather along a route of [points] at the specified [time].
+  Future<Map<String, dynamic>> evaluateRoute(
+    List<GeoPoint> points,
+    DateTime time,
+    WeatherLimits limits,
+  ) async {
+    final uri = Uri.parse('${ApiService.baseUrl}/api/forecast/route');
+    final body = {
+      'points':
+          points.map((p) => {'latitude': p.latitude, 'longitude': p.longitude}).toList(),
+      'time': time.toIso8601String(),
+      'thresholds': limits.toJson(),
+    };
+
+    final response =
+        await _client.post(uri, headers: await _getHeaders(), body: jsonEncode(body));
+
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else {
+      throw Exception('Failed to evaluate route: ${response.statusCode}');
     }
   }
 

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -62,8 +62,8 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
         : result.status == 'warning'
             ? Icons.warning
             : Icons.check_circle;
-    final headwind = parseDouble(result.forecast['headwind']);
-    final crosswind = parseDouble(result.forecast['crosswind']);
+    final headwind = parseDouble(result.summary['max_headwind']);
+    final crosswind = parseDouble(result.summary['max_crosswind']);
     return Card(
       margin: const EdgeInsets.all(16),
       color: color.withOpacity(0.1),
@@ -87,11 +87,13 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
               style: theme.textTheme.bodySmall,
             ),
             const SizedBox(height: 12),
-            _metricRow('Temperature',
-                '${result.forecast['temp']}°C',
+            _metricRow(
+                'Temperature',
+                '${result.summary['min_temp']} - ${result.summary['max_temp']}°C',
                 'range ${limits.minTemperature}-${limits.maxTemperature}°C'),
-            _metricRow('Wind speed',
-                '${result.forecast['wind_speed']} m/s',
+            _metricRow(
+                'Wind speed',
+                '${result.summary['max_wind_speed']} m/s',
                 'max ${limits.maxWindSpeed} m/s'),
             _metricRow('Headwind',
                 '${headwind.toStringAsFixed(1)} m/s',
@@ -100,10 +102,10 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
                 '${crosswind.toStringAsFixed(1)} m/s',
                 'max ${limits.crosswindSensitivity} m/s'),
             _metricRow('Rain',
-                '${result.forecast['rain'] ?? 0} mm',
+                '${result.summary['max_rain'] ?? 0} mm',
                 'max ${limits.maxRainIntensity} mm'),
             _metricRow('Humidity',
-                '${result.forecast['humidity']}%',
+                '${result.summary['max_humidity']}%',
                 'max ${limits.maxHumidity}%'),
             if (result.issues.isNotEmpty)
               Padding(

--- a/ride_aware_frontend/test/forecast_service_test.dart
+++ b/ride_aware_frontend/test/forecast_service_test.dart
@@ -5,6 +5,8 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:active_commuter_support/services/forecast_service.dart';
 import 'package:active_commuter_support/services/device_id_service.dart';
+import 'package:active_commuter_support/models/geo_point.dart';
+import 'package:active_commuter_support/models/user_preferences.dart';
 
 class _FakeDeviceIdService extends DeviceIdService {
   @override
@@ -43,5 +45,32 @@ void main() {
     expect(result['visibility'], isA<double>());
     expect(result['uvi'], isA<double>());
     expect(result['clouds'], isA<double>());
+  });
+
+  test('evaluateRoute posts points and returns data', () async {
+    final mockClient = MockClient((request) async {
+      expect(request.method, equals('POST'));
+      expect(request.url.path, contains('/api/forecast/route'));
+      return http.Response(
+          jsonEncode({
+            'status': 'ok',
+            'issues': [],
+            'borderline': [],
+            'summary': {'max_wind_speed': 5}
+          }),
+          200);
+    });
+
+    final service = ForecastService(
+      client: mockClient,
+      deviceIdService: _FakeDeviceIdService(),
+    );
+
+    final res = await service.evaluateRoute(
+      [GeoPoint(latitude: 0, longitude: 0)],
+      DateTime.now(),
+      WeatherLimits.defaultValues(),
+    );
+    expect(res['summary']['max_wind_speed'], 5);
   });
 }


### PR DESCRIPTION
## Summary
- evaluate weather across multiple route points with new backend endpoint
- fetch and display aggregated route forecast and warnings on the dashboard
- cover new route forecast service with tests

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e941c7048328833cfeadd7107dbc