### PR TITLE
feat: redesign upcoming commute alert card

### DIFF
--- a/ride_aware_frontend/lib/utils/i18n.dart
+++ b/ride_aware_frontend/lib/utils/i18n.dart
@@ -1,0 +1,3 @@
+/// Placeholder localization function.
+/// Replace with real i18n lookup in production.
+String t(String message) => message;

--- a/ride_aware_frontend/lib/widgets/commute_summary.dart
+++ b/ride_aware_frontend/lib/widgets/commute_summary.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../utils/i18n.dart';
+
+class CommuteSummary extends StatelessWidget {
+  final String dateLabel;
+  final String routeName;
+
+  const CommuteSummary({
+    super.key,
+    required this.dateLabel,
+    required this.routeName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Icon(Icons.calendar_today, size: 20),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            t('Next Commute: $dateLabel – Route: "$routeName"'),
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import '../viewmodels/upcoming_commute_view_model.dart';
 import '../utils/parsing.dart';
+import '../utils/i18n.dart';
+import 'commute_summary.dart';
+import 'weather_metric_card.dart';
 
 class UpcomingCommuteAlert extends StatefulWidget {
   const UpcomingCommuteAlert({super.key});
@@ -46,74 +49,162 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
         margin: const EdgeInsets.all(16),
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Text('Error: ${_vm.error}'),
+          child: Text(t('Error: ${_vm.error}')),
         ),
       );
     }
+
     final result = _vm.result!;
     final limits = result.limits;
-    final color = result.status == 'alert'
-        ? Colors.red
-        : result.status == 'warning'
-            ? Colors.amber
-            : Colors.green;
-    final icon = result.status == 'alert'
-        ? Icons.error
-        : result.status == 'warning'
-            ? Icons.warning
-            : Icons.check_circle;
-    final headwind = parseDouble(result.summary['max_headwind']);
-    final crosswind = parseDouble(result.summary['max_crosswind']);
+    final status = _statusInfo(result.status);
+
+    // Temperature evaluation
+    final minTemp = parseDouble(result.summary['min_temp']);
+    final maxTemp = parseDouble(result.summary['max_temp']);
+    String tempCaption;
+    IconData tempIcon;
+    Color tempColor;
+    if (minTemp < limits.minTemperature) {
+      tempCaption = 'Feels Cold';
+      tempIcon = Icons.ac_unit;
+      tempColor = Colors.amber;
+    } else if (maxTemp > limits.maxTemperature) {
+      tempCaption = 'Feels Warm';
+      tempIcon = Icons.local_fire_department;
+      tempColor = Colors.amber;
+    } else {
+      tempCaption = 'Comfortable';
+      tempIcon = Icons.thermostat;
+      tempColor = Colors.green;
+    }
+    final tempDesc =
+        'Forecast: ${minTemp.toStringAsFixed(0)}°C–${maxTemp.toStringAsFixed(0)}°C • Your comfort range: ${limits.minTemperature}°C–${limits.maxTemperature}°C';
+
+    // Wind speed
+    final windSpeed = parseDouble(result.summary['max_wind_speed']) * 3.6;
+    final windLimit = limits.maxWindSpeed * 3.6;
+    final windColor = _levelColor(windSpeed, windLimit);
+    final windIcon = windColor == Colors.green ? Icons.air : Icons.warning;
+    final windDesc =
+        'Strong gusts up to ${windSpeed.toStringAsFixed(0)} km/h (Your limit: ${windLimit.toStringAsFixed(0)} km/h)';
+
+    // Headwind & Crosswind
+    final headwind = parseDouble(result.summary['max_headwind']) * 3.6;
+    final crosswind = parseDouble(result.summary['max_crosswind']) * 3.6;
+    final headLimit = limits.headwindSensitivity * 3.6;
+    final crossLimit = limits.crosswindSensitivity * 3.6;
+    final headRisk = _riskLevel(headwind, headLimit);
+    final crossRisk = _riskLevel(crosswind, crossLimit);
+    final windDirColor = _combineColors(
+      _riskColor(headwind, headLimit),
+      _riskColor(crosswind, crossLimit),
+    );
+    final windDirDesc =
+        'Headwind risk: $headRisk • Crosswind: $crossRisk (Your limits: Headwind ${headLimit.toStringAsFixed(0)} km/h, Crosswind ${crossLimit.toStringAsFixed(0)} km/h)';
+
+    // Rain
+    final rain = parseDouble(result.summary['max_rain']);
+    final rainLimit = limits.maxRainIntensity;
+    final rainColor = _levelColor(rain, rainLimit);
+    final rainDesc =
+        'Expected: ${rain.toStringAsFixed(1)} mm/hr • You’re comfortable up to: ${rainLimit.toStringAsFixed(1)} mm/hr';
+
+    // Humidity
+    final humidity = parseDouble(result.summary['max_humidity']);
+    final humidityLimit = limits.maxHumidity.toDouble();
+    final humidityColor = _levelColor(humidity, humidityLimit);
+    final humidityDesc =
+        'Forecast: ${humidity.toStringAsFixed(0)}% • You prefer ≤ ${humidityLimit.toStringAsFixed(0)}%';
+
     return Card(
       margin: const EdgeInsets.all(16),
-      color: color.withOpacity(0.1),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: status.color.withOpacity(0.1),
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(4)),
+            ),
+            child: Row(
               children: [
-                Icon(icon, color: color),
-                const SizedBox(width: 8),
-                Text('Upcoming Commute Alert',
-                    style: theme.textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.bold, color: color)),
+                Expanded(
+                  child: Text(
+                    t('Upcoming Commute'),
+                    style: theme.textTheme.titleLarge
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Icon(status.icon, color: status.color),
+                const SizedBox(width: 4),
+                Text(
+                  t(status.label),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: status.color,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
               ],
             ),
-            const SizedBox(height: 4),
-            Text(
-              'Next ride: ${_formatDateTime(result.time)}, Route: ${result.route.routeName}',
-              style: theme.textTheme.bodySmall,
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CommuteSummary(
+                  dateLabel: _formatDateTime(result.time),
+                  routeName: result.route.routeName,
+                ),
+                const SizedBox(height: 12),
+                WeatherMetricCard(
+                  icon: tempIcon,
+                  caption: tempCaption,
+                  description: tempDesc,
+                  color: tempColor,
+                ),
+                WeatherMetricCard(
+                  icon: windIcon,
+                  caption: 'Wind Gusts',
+                  description: windDesc,
+                  color: windColor,
+                ),
+                WeatherMetricCard(
+                  icon: Icons.explore,
+                  caption: 'Wind Direction Impact',
+                  description: windDirDesc,
+                  color: windDirColor,
+                ),
+                WeatherMetricCard(
+                  icon: Icons.umbrella,
+                  caption: 'Chance of Rain',
+                  description: rainDesc,
+                  color: rainColor,
+                ),
+                WeatherMetricCard(
+                  icon: Icons.opacity,
+                  caption: 'Humidity',
+                  description: humidityDesc,
+                  color: humidityColor,
+                ),
+                if (result.issues.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  _issuesSection(result, status.color, theme),
+                ],
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: ElevatedButton.icon(
+                    onPressed: _vm.load,
+                    icon: const Icon(Icons.refresh),
+                    label: Text(t('Re-evaluate Commute')),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 12),
-            _metricRow(
-                'Temperature',
-                '${result.summary['min_temp']} - ${result.summary['max_temp']}°C',
-                'range ${limits.minTemperature}-${limits.maxTemperature}°C'),
-            _metricRow(
-                'Wind speed',
-                '${result.summary['max_wind_speed']} m/s',
-                'max ${limits.maxWindSpeed} m/s'),
-            _metricRow('Headwind',
-                '${headwind.toStringAsFixed(1)} m/s',
-                'max ${limits.headwindSensitivity} m/s'),
-            _metricRow('Crosswind',
-                '${crosswind.toStringAsFixed(1)} m/s',
-                'max ${limits.crosswindSensitivity} m/s'),
-            _metricRow('Rain',
-                '${result.summary['max_rain'] ?? 0} mm',
-                'max ${limits.maxRainIntensity} mm'),
-            _metricRow('Humidity',
-                '${result.summary['max_humidity']}%',
-                'max ${limits.maxHumidity}%'),
-            if (result.issues.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.only(top: 12),
-                child: _issuesSection(result, color, theme),
-              ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -134,7 +225,7 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
             children: [
               Icon(Icons.warning_amber, size: 16, color: color),
               const SizedBox(width: 6),
-              Text('Issues',
+              Text(t('Issues'),
                   style: theme.textTheme.titleSmall
                       ?.copyWith(color: color, fontWeight: FontWeight.w600)),
             ],
@@ -161,11 +252,11 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text('No commute time set'),
+            Text(t('No commute time set')),
             const SizedBox(height: 8),
             ElevatedButton(
               onPressed: _pickTime,
-              child: const Text('Set Ride Time'),
+              child: Text(t('Set Ride Time')),
             ),
           ],
         ),
@@ -200,28 +291,47 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
     return '$day $hour:$minute $ampm';
   }
 
-  Widget _metricRow(String label, String value, String threshold) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(label, style: theme.textTheme.bodySmall),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Text(value,
-                  style: theme.textTheme.bodyMedium
-                      ?.copyWith(fontWeight: FontWeight.bold)),
-              Text(threshold,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                      fontSize: 10)),
-            ],
-          ),
-        ],
-      ),
-    );
+  _StatusInfo _statusInfo(String status) {
+    switch (status) {
+      case 'alert':
+        return const _StatusInfo(
+            Colors.red, Icons.close, 'Unfavourable Conditions');
+      case 'warning':
+        return const _StatusInfo(Colors.amber, Icons.warning, 'Caution');
+      default:
+        return const _StatusInfo(Colors.green, Icons.check, 'All Clear');
+    }
   }
+
+  Color _levelColor(double value, double limit) {
+    if (value > limit) return Colors.red;
+    if (value > limit * 0.7) return Colors.amber;
+    return Colors.green;
+  }
+
+  String _riskLevel(double value, double limit) {
+    if (value > limit) return 'High';
+    if (value > limit * 0.7) return 'Moderate';
+    return 'Low';
+  }
+
+  Color _riskColor(double value, double limit) {
+    if (value > limit) return Colors.red;
+    if (value > limit * 0.7) return Colors.amber;
+    return Colors.green;
+  }
+
+  Color _combineColors(Color a, Color b) {
+    if (a == Colors.red || b == Colors.red) return Colors.red;
+    if (a == Colors.amber || b == Colors.amber) return Colors.amber;
+    return Colors.green;
+  }
+
+}
+
+class _StatusInfo {
+  final Color color;
+  final IconData icon;
+  final String label;
+  const _StatusInfo(this.color, this.icon, this.label);
 }

--- a/ride_aware_frontend/lib/widgets/weather_metric_card.dart
+++ b/ride_aware_frontend/lib/widgets/weather_metric_card.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import '../utils/i18n.dart';
+
+class WeatherMetricCard extends StatelessWidget {
+  final IconData icon;
+  final String caption;
+  final String description;
+  final Color color;
+
+  const WeatherMetricCard({
+    super.key,
+    required this.icon,
+    required this.caption,
+    required this.description,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  t(caption),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  t(description),
+                  style: theme.textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder i18n helper
- introduce reusable CommuteSummary and WeatherMetricCard widgets
- revamp UpcomingCommuteAlert with descriptive metrics, status banner, and re-evaluate button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890f3cdabdc8328a95d1a376fdced17