### PR TITLE
Refactor shared DB ops and streamline API requests

### DIFF
--- a/ride_aware_backend/controllers/threshold_controller.py
+++ b/ride_aware_backend/controllers/threshold_controller.py
@@ -2,6 +2,7 @@ import logging
 from fastapi import HTTPException
 from models.thresholds import Thresholds
 from services.db import thresholds_collection
+from services.db_utils import fetch_by_device_id, upsert_by_device_id
 
 
 logger = logging.getLogger(__name__)
@@ -10,37 +11,17 @@ logger = logging.getLogger(__name__)
 async def upsert_threshold(threshold: Thresholds) -> dict:
     data = threshold.model_dump(mode="json")
     device_id = data["device_id"]
-    logger.info("Upserting thresholds for device %s", device_id)
-
-    result = await thresholds_collection.update_one(
-        {"device_id": device_id},
-        {"$set": data},
-        upsert=True,
+    return await upsert_by_device_id(
+        thresholds_collection, data, device_id, logger
     )
-    logger.info("Thresholds upserted for device %s", device_id)
-    logger.debug(
-        "Upsert result for %s: modified=%s upserted_id=%s",
-        device_id,
-        getattr(result, "modified_count", None),
-        getattr(result, "upserted_id", None),
-    )
-
-    return {
-        "device_id": device_id,
-        "status": "ok",
-        "modified_count": getattr(result, "modified_count", None),
-        "upserted_id": str(getattr(result, "upserted_id", "")) or None,
-    }
 
 
 async def get_thresholds(device_id: str) -> dict:
-    logger.info("Retrieving thresholds for device %s", device_id)
-    doc = await thresholds_collection.find_one({"device_id": device_id})
-    if not doc:
-        logger.warning("Thresholds not found for device %s", device_id)
-        raise HTTPException(status_code=404, detail="Thresholds not found")
-
-    # Remove _id and validate through model
-    doc.pop("_id", None)
-    return Thresholds(**doc).model_dump(mode="json")
+    return await fetch_by_device_id(
+        thresholds_collection,
+        device_id,
+        Thresholds,
+        "Thresholds not found",
+        logger,
+    )
 

--- a/ride_aware_backend/services/db_utils.py
+++ b/ride_aware_backend/services/db_utils.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Any, Dict, Type, TypeVar
+
+from fastapi import HTTPException
+from pymongo.collection import Collection
+
+ModelT = TypeVar("ModelT")
+
+
+async def fetch_by_device_id(
+    collection: Collection,
+    device_id: str,
+    model_cls: Type[ModelT],
+    not_found_msg: str,
+    logger: logging.Logger,
+) -> Dict[str, Any]:
+    """Retrieve and validate a document by device_id."""
+    col_name = getattr(collection, "name", collection.__class__.__name__)
+    logger.info("Retrieving %s for device %s", col_name, device_id)
+    doc = await collection.find_one({"device_id": device_id})
+    if not doc:
+        logger.warning("%s not found for device %s", col_name, device_id)
+        raise HTTPException(status_code=404, detail=not_found_msg)
+    doc.pop("_id", None)
+    logger.debug("%s document for %s: %s", col_name, device_id, doc)
+    return model_cls(**doc).model_dump(mode="json")
+
+
+async def upsert_by_device_id(
+    collection: Collection,
+    data: Dict[str, Any],
+    device_id: str,
+    logger: logging.Logger,
+) -> Dict[str, Any]:
+    """Upsert a document identified by device_id."""
+    col_name = getattr(collection, "name", collection.__class__.__name__)
+    logger.info("Upserting %s for device %s", col_name, device_id)
+    result = await collection.update_one(
+        {"device_id": device_id},
+        {"$set": data},
+        upsert=True,
+    )
+    logger.debug(
+        "Upsert result for %s in %s: modified=%s upserted_id=%s",
+        device_id,
+        col_name,
+        getattr(result, "modified_count", None),
+        getattr(result, "upserted_id", None),
+    )
+    return {
+        "device_id": device_id,
+        "status": "ok",
+        "modified_count": getattr(result, "modified_count", None),
+        "upserted_id": str(getattr(result, "upserted_id", "")) or None,
+    }


### PR DESCRIPTION
## Summary
- centralize device-specific database fetch/upsert logic
- reuse POST helper in frontend API service
- simplify controllers with shared utilities

## Testing
- `pytest`
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(failed: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68912cbf359c832884f63585d7c001b0