### PR TITLE
Add humidity warning popup for high levels

### DIFF
--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -12,6 +12,7 @@ class _WeatherMetric {
   final String description;
   final String subDescription;
   final Color color;
+  final VoidCallback? onTap;
 
   const _WeatherMetric(
     this.icon,
@@ -19,6 +20,7 @@ class _WeatherMetric {
     this.description,
     this.subDescription,
     this.color,
+    [this.onTap],
   );
 }
 
@@ -329,6 +331,7 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
               humidityDesc,
               humiditySubDesc,
               humidityColor,
+              humidity > humidityLimit ? _showHumidityAlert : null,
             ),
           ], theme),
         ],
@@ -371,7 +374,7 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
     ThemeData theme, {
     bool isFullWidth = false,
   }) {
-    return Container(
+    final card = Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -431,6 +434,27 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
+          ),
+        ],
+      ),
+    );
+
+    if (metric.onTap != null) {
+      return GestureDetector(onTap: metric.onTap, child: card);
+    }
+    return card;
+  }
+
+  void _showHumidityAlert() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(t('High Humidity')),
+        content: Text(t('Bring extra bottle')),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(t('OK')),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- make _WeatherMetric support tap callbacks
- show alert suggesting to bring an extra bottle when humidity exceeds user limit

## Testing
- `dart format lib/widgets/upcoming_commute_alert.dart` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package)*
- `sudo apt-get install -y flutter` *(fails: Unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68914e22b7988328a74812606acffeac