### PR TITLE
Ensure humidity card alert is tappable

### DIFF
--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -440,7 +440,14 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
     );
 
     if (metric.onTap != null) {
-      return GestureDetector(onTap: metric.onTap, child: card);
+      return Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: metric.onTap,
+          child: card,
+        ),
+      );
     }
     return card;
   }


### PR DESCRIPTION
## Summary
- Replace `GestureDetector` with `InkWell` wrapped in `Material` so tapping the humidity card opens the alert dialog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891512b8b048328b31d0a9eafccbc32