### PR TITLE
Make out-of-threshold weather cards tappable

### DIFF
--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -12,7 +12,6 @@ class _WeatherMetric {
   final String description;
   final String subDescription;
   final Color color;
-  final VoidCallback? onTap;
 
   const _WeatherMetric(
     this.icon,
@@ -20,7 +19,6 @@ class _WeatherMetric {
     this.description,
     this.subDescription,
     this.color,
-    [this.onTap],
   );
 }
 
@@ -331,7 +329,6 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
               humidityDesc,
               humiditySubDesc,
               humidityColor,
-              humidity > humidityLimit ? _showHumidityAlert : null,
             ),
           ], theme),
         ],
@@ -439,18 +436,29 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
       ),
     );
 
-    if (metric.onTap != null) {
-      return GestureDetector(onTap: metric.onTap, child: card);
+    if (metric.color == Colors.red) {
+      return GestureDetector(
+        onTap: () => _showConditionWarning(context, metric.caption),
+        child: card,
+      );
     }
     return card;
   }
 
-  void _showHumidityAlert() {
+  void _showConditionWarning(BuildContext context, String metricName) {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(t('High Humidity')),
-        content: Text(t('Bring extra bottle')),
+        title: Text(t('$metricName Alert')),
+        content: Text(
+          metricName == 'Humidity'
+              ? t(
+                  'Humidity is above your set range. Consider bringing an extra water bottle.',
+                )
+              : t(
+                  '$metricName is outside your preferred range. Weather condition is bad, be careful.',
+                ),
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),


### PR DESCRIPTION
## Summary
- Wrap red weather cards with a `GestureDetector` to show a warning dialog
- Provide humidity-specific advice and generic warnings for other metrics
- Simplify `_WeatherMetric` by dropping unused `onTap` callback

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68915204ddb883289840ff78916512e8