### PR TITLE
Enable core library desugaring for Android build

### DIFF
--- a/ride_aware_frontend/android/app/build.gradle.kts
+++ b/ride_aware_frontend/android/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -44,4 +45,9 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Enable Java 8+ API desugaring required by flutter_local_notifications
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring for the Android app
- add desugaring dependency needed by flutter_local_notifications

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `gradle app:checkDebugAarMetadata` *(fails: local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68917517f8a483289719b1de6caa8ca2