### PR TITLE
fix: show post-ride feedback after commute

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -54,15 +54,15 @@ class _DashboardScreenState extends State<DashboardScreen> {
     final now = TimeOfDay.now();
     final morning = _prefs!.commuteWindows.morningLocal;
     final evening = _prefs!.commuteWindows.eveningLocal;
-    bool after(TimeOfDay a, TimeOfDay b) =>
+    bool isAfter(TimeOfDay a, TimeOfDay b) =>
         a.hour > b.hour || (a.hour == b.hour && a.minute >= b.minute);
-    bool before(TimeOfDay a, TimeOfDay b) =>
-        a.hour < b.hour || (a.hour == b.hour && a.minute < b.minute);
-    if (!_morningFeedbackGiven && after(now, morning) && before(now, evening)) {
-      return 'morning';
-    }
-    if (!_eveningFeedbackGiven && after(now, evening)) {
+    // Prioritize evening feedback once the evening commute has passed.
+    if (!_eveningFeedbackGiven && isAfter(now, evening)) {
       return 'evening';
+    }
+    // Show morning feedback any time after the morning commute until it is given.
+    if (!_morningFeedbackGiven && isAfter(now, morning)) {
+      return 'morning';
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- fix pending feedback logic so dashboard shows morning or evening ride feedback once commute has passed

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689178b163008328a3612a859e1a3d27