### PR TITLE
Ensure notifications scheduled in future and add debug test

### DIFF
--- a/ride_aware_frontend/test/notification_service_test.dart
+++ b/ride_aware_frontend/test/notification_service_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ride_aware_frontend/services/notification_service.dart';
+
+void main() {
+  final service = NotificationService();
+
+  test('rolls past times forward one day', () {
+    final now = DateTime.now();
+    final past = now.subtract(const Duration(hours: 1));
+    final adjusted = service.rollForwardIfPast(past);
+    expect(adjusted.isAfter(now), isTrue);
+    expect(adjusted.difference(past).inDays, 1);
+  });
+
+  test('keeps future times unchanged', () {
+    final now = DateTime.now();
+    final future = now.add(const Duration(hours: 1));
+    final adjusted = service.rollForwardIfPast(future);
+    expect(adjusted, future);
+  });
+}


### PR DESCRIPTION
## Summary
- Roll past commute notification times forward to the next day before scheduling
- Schedule a debug-only notification 5 seconds after startup for quick verification
- Add unit tests for notification time rolling logic

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68917efc073c83288b0379b4a2d27998