### PR TITLE
Handle errors loading violations in feedback screen

### DIFF
--- a/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
+++ b/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
@@ -44,10 +44,15 @@ class _PostRideFeedbackScreenState extends State<PostRideFeedbackScreen> {
       body: FutureBuilder<List<String>>(
         future: _violationsFuture,
         builder: (context, snapshot) {
-          if (!snapshot.hasData) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           }
-          final v = snapshot.data!;
+          if (snapshot.hasError) {
+            return const Center(
+              child: Text('Failed to load feedback questions'),
+            );
+          }
+          final v = snapshot.data ?? [];
           return ListView(
             padding: const EdgeInsets.all(16),
             children: [


### PR DESCRIPTION
## Summary
- Prevent crash in PostRideFeedbackScreen by waiting for commute status load, surfacing errors, and handling missing data.

## Testing
- `dart format lib/screens/post_ride_feedback_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68918a6226a883289eaeb55b268bf5ca