### PR TITLE
Show error and retry option when loading feedback questions fails

### DIFF
--- a/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
+++ b/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
@@ -48,8 +48,25 @@ class _PostRideFeedbackScreenState extends State<PostRideFeedbackScreen> {
             return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
-            return const Center(
-              child: Text('Failed to load feedback questions'),
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Failed to load feedback questions: ${snapshot.error}',
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      setState(() {
+                        _violationsFuture = _loadViolations();
+                      });
+                    },
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
             );
           }
           final v = snapshot.data ?? [];


### PR DESCRIPTION
## Summary
- display error message with details when feedback questions fail to load
- allow users to retry loading feedback questions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68918d5c08088328bfa5d64910620973