### PR TITLE
Display ride feedback summary in upcoming commute alert

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -150,7 +150,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
               ),
 
             // Commute Status Panel
-            const UpcomingCommuteAlert(),
+            UpcomingCommuteAlert(feedbackSummary: _feedbackSummary),
 
             // Notification Status Card
             Card(

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -33,7 +33,12 @@ class _StatusInfo {
 }
 
 class UpcomingCommuteAlert extends StatefulWidget {
-  const UpcomingCommuteAlert({super.key});
+  final String feedbackSummary;
+
+  const UpcomingCommuteAlert({
+    super.key,
+    this.feedbackSummary = 'You did a great job!',
+  });
 
   @override
   State<UpcomingCommuteAlert> createState() => _UpcomingCommuteAlertState();
@@ -171,10 +176,14 @@ class _UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
                         children: [
                           const Icon(Icons.thumb_up, color: Colors.green),
                           const SizedBox(width: 8),
-                          Text(
-                            'You did a great job!',
-                            style: theme.textTheme.titleSmall?.copyWith(
-                              fontWeight: FontWeight.bold,
+                          Expanded(
+                            child: Text(
+                              widget.feedbackSummary.isNotEmpty
+                                  ? widget.feedbackSummary
+                                  : 'You did a great job!',
+                              style: theme.textTheme.titleSmall?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                           ),
                         ],


### PR DESCRIPTION
## Summary
- Add `feedbackSummary` prop to `UpcomingCommuteAlert`
- Show ride feedback summary in post-commute card, defaulting to "You did a great job!"
- Pass feedback summary from `DashboardScreen`

## Testing
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68919283838c832893597b318cc5dbf3