### PR TITLE
Fix threshold adjust numeric input formatting

### DIFF
--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -802,7 +802,13 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
         signed: true,
       ),
       inputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp(r'^-?\\d*\\.?\\d*')),
+        // Allow optional leading minus sign and decimal numbers.
+        // The previous regex mistakenly escaped the digit matcher (\d),
+        // blocking numeric input. This pattern restores responsiveness while
+        // still restricting input to valid numeric characters.
+        FilteringTextInputFormatter.allow(
+          RegExp(r'^-?[0-9]*\.?[0-9]*'),
+        ),
       ],
       decoration: InputDecoration(
         labelText: label,


### PR DESCRIPTION
## Summary
- fix numeric input formatter in threshold adjust card so keypad input works

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6891a1dabe4083289068ba431eed5c0e