### PR TITLE
Persist ride feedback completion

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -38,8 +38,10 @@ class _DashboardScreenState extends State<DashboardScreen>
 
   Future<void> _loadPrefs() async {
     final p = await _prefsService.loadPreferences();
+    final feedbackGiven = await _prefsService.isEveningFeedbackGivenToday();
     setState(() {
       _prefs = p;
+      _eveningFeedbackGiven = feedbackGiven;
     });
   }
 
@@ -57,6 +59,7 @@ class _DashboardScreenState extends State<DashboardScreen>
       _eveningFeedbackGiven = false;
       _feedbackSummary = 'You did a great job!';
       _lastReset = now;
+      _prefsService.clearEveningFeedbackGiven();
     }
   }
 
@@ -158,6 +161,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                               _feedbackSummary = result['summary'] as String;
                               _eveningFeedbackGiven = true;
                             });
+                            _prefsService
+                                .setEveningFeedbackGiven(DateTime.now());
                           }
                         },
                 ),

--- a/ride_aware_frontend/lib/services/preferences_service.dart
+++ b/ride_aware_frontend/lib/services/preferences_service.dart
@@ -8,6 +8,7 @@ class PreferencesService {
   static const String _preferencesKey = 'user_preferences';
   static const String _thresholdsSetKey = 'thresholdsSet';
   static const String _prefsVersionKey = 'prefsVersion';
+  static const String _lastEveningFeedbackKey = 'lastEveningFeedback';
 
   final DeviceIdService _deviceIdService = DeviceIdService();
 
@@ -87,5 +88,28 @@ class PreferencesService {
   Future<bool> hasStoredPreferences() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.containsKey(_preferencesKey);
+  }
+
+  Future<void> setEveningFeedbackGiven(DateTime date) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        _lastEveningFeedbackKey, date.toIso8601String());
+  }
+
+  Future<bool> isEveningFeedbackGivenToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dateStr = prefs.getString(_lastEveningFeedbackKey);
+    if (dateStr == null) return false;
+    final date = DateTime.tryParse(dateStr);
+    if (date == null) return false;
+    final now = DateTime.now();
+    return now.year == date.year &&
+        now.month == date.month &&
+        now.day == date.day;
+  }
+
+  Future<void> clearEveningFeedbackGiven() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_lastEveningFeedbackKey);
   }
 }


### PR DESCRIPTION
## Summary
- Persist evening ride feedback completion in shared preferences
- Load and clear feedback status to prevent card from reappearing after restart

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a60670408328a284e4a5b2ce306b