### PR TITLE
feat: notify when ride feedback available

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -22,6 +22,7 @@ class _DashboardScreenState extends State<DashboardScreen>
   String _feedbackSummary = 'You did a great job!';
   bool _eveningFeedbackGiven = false;
   DateTime _lastReset = DateTime.now();
+  bool _feedbackNotificationShown = false;
 
   final GlobalKey<UpcomingCommuteAlertState> _alertKey =
       GlobalKey<UpcomingCommuteAlertState>();
@@ -60,6 +61,7 @@ class _DashboardScreenState extends State<DashboardScreen>
       _feedbackSummary = 'You did a great job!';
       _lastReset = now;
       _prefsService.clearEveningFeedbackGiven();
+      _feedbackNotificationShown = false;
     }
   }
 
@@ -83,6 +85,10 @@ class _DashboardScreenState extends State<DashboardScreen>
   Widget build(BuildContext context) {
     _resetFlagsIfNewDay();
     final showFeedback = _shouldShowFeedbackCard();
+    if (showFeedback && !_eveningFeedbackGiven && !_feedbackNotificationShown) {
+      _notificationService.showFeedbackNotification();
+      _feedbackNotificationShown = true;
+    }
     return Scaffold(
       appBar: AppBar(
         title: const Text('Dashboard'),

--- a/ride_aware_frontend/lib/services/notification_service.dart
+++ b/ride_aware_frontend/lib/services/notification_service.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'api_service.dart';
 
 class NotificationService {
@@ -10,6 +11,8 @@ class NotificationService {
 
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
   final ApiService _apiService = ApiService();
+  final FlutterLocalNotificationsPlugin _localNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
 
   String? _fcmToken;
 
@@ -35,6 +38,13 @@ class NotificationService {
       }
 
       if (settings.authorizationStatus == AuthorizationStatus.authorized) {
+        // Initialize local notifications
+        const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+        const iosSettings = DarwinInitializationSettings();
+        const initSettings = InitializationSettings(
+            android: androidSettings, iOS: iosSettings);
+        await _localNotificationsPlugin.initialize(initSettings);
+
         // Get the FCM token
         await _getFCMToken();
 
@@ -136,6 +146,24 @@ class NotificationService {
 
   /// Get current FCM token
   String? get fcmToken => _fcmToken;
+
+  /// Show a local notification indicating feedback is available
+  Future<void> showFeedbackNotification() async {
+    const androidDetails = AndroidNotificationDetails(
+      'feedback_channel',
+      'Ride Feedback',
+      channelDescription: 'Notifications for ride feedback availability',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+    const notificationDetails = NotificationDetails(android: androidDetails);
+    await _localNotificationsPlugin.show(
+      0,
+      'Ride feedback ready',
+      'Please provide feedback for your last ride.',
+      notificationDetails,
+    );
+  }
 
   /// Check if notifications are enabled
   Future<bool> areNotificationsEnabled() async {

--- a/ride_aware_frontend/pubspec.yaml
+++ b/ride_aware_frontend/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   crypto: ^3.0.3 # Added for SHA-256 hashing
   firebase_core: ^2.24.0      # Add Firebase Core
   firebase_messaging: ^14.7.0 # Add Firebase Messaging
+  flutter_local_notifications: ^17.1.2 # For local notifications
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- add flutter_local_notifications dependency
- initialize local notifications and expose a method to show feedback-ready alerts
- trigger a notification when the ride feedback card becomes available

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a90d4a6083289a4c6a9c295a236a