### PR TITLE
Add indexed thresholds and feedback links

### DIFF
--- a/ride_aware_backend/controllers/ride_history_controller.py
+++ b/ride_aware_backend/controllers/ride_history_controller.py
@@ -10,7 +10,12 @@ logger = logging.getLogger(__name__)
 async def save_ride(entry: RideHistoryEntry) -> dict:
     try:
         await ride_history_collection.insert_one(entry.model_dump(mode="json"))
-        logger.info("Ride history saved for device %s on %s", entry.device_id, entry.date)
+        logger.info(
+            "Ride history saved for device %s on %s (threshold %s)",
+            entry.device_id,
+            entry.date,
+            entry.threshold_id,
+        )
         return {"status": "ok"}
     except PyMongoError as e:
         logger.error("Database error saving ride history for %s: %s", entry.device_id, e)

--- a/ride_aware_backend/controllers/threshold_controller.py
+++ b/ride_aware_backend/controllers/threshold_controller.py
@@ -10,14 +10,29 @@ logger = logging.getLogger(__name__)
 async def upsert_threshold(threshold: Thresholds) -> dict:
     data = threshold.model_dump(mode="json")
     device_id = data["device_id"]
-    logger.info("Upserting thresholds for device %s", device_id)
+    date = data["date"]
+    start_time = data["start_time"]
+    logger.info(
+        "Upserting thresholds for device %s on %s at %s", device_id, date, start_time
+    )
+
+    filter_doc = {
+        "device_id": device_id,
+        "date": date,
+        "start_time": start_time,
+    }
 
     result = await thresholds_collection.update_one(
-        {"device_id": device_id},
+        filter_doc,
         {"$set": data},
         upsert=True,
     )
-    logger.info("Thresholds upserted for device %s", device_id)
+    logger.info(
+        "Thresholds upserted for device %s on %s at %s",
+        device_id,
+        date,
+        start_time,
+    )
     logger.debug(
         "Upsert result for %s: modified=%s upserted_id=%s",
         device_id,
@@ -27,17 +42,28 @@ async def upsert_threshold(threshold: Thresholds) -> dict:
 
     return {
         "device_id": device_id,
+        "date": date,
+        "start_time": start_time,
         "status": "ok",
         "modified_count": getattr(result, "modified_count", None),
         "upserted_id": str(getattr(result, "upserted_id", "")) or None,
     }
 
 
-async def get_thresholds(device_id: str) -> dict:
-    logger.info("Retrieving thresholds for device %s", device_id)
-    doc = await thresholds_collection.find_one({"device_id": device_id})
+async def get_thresholds(device_id: str, date: str, start_time: str) -> dict:
+    logger.info(
+        "Retrieving thresholds for device %s on %s at %s", device_id, date, start_time
+    )
+    doc = await thresholds_collection.find_one(
+        {"device_id": device_id, "date": date, "start_time": start_time}
+    )
     if not doc:
-        logger.warning("Thresholds not found for device %s", device_id)
+        logger.warning(
+            "Thresholds not found for device %s on %s at %s",
+            device_id,
+            date,
+            start_time,
+        )
         raise HTTPException(status_code=404, detail="Thresholds not found")
 
     # Remove _id and validate through model

--- a/ride_aware_backend/main.py
+++ b/ride_aware_backend/main.py
@@ -1,6 +1,7 @@
 import logging
 from fastapi import FastAPI
 from routes import thresholds, routes, fcm, commute_status, forecast, feedback, ride_history
+from services.db import init_db
 
 
 logging.basicConfig(
@@ -18,3 +19,8 @@ app.include_router(commute_status.router)
 app.include_router(forecast.router)
 app.include_router(feedback.router)
 app.include_router(ride_history.router)
+
+
+@app.on_event("startup")
+async def startup_event():
+    await init_db()

--- a/ride_aware_backend/models/feedback.py
+++ b/ride_aware_backend/models/feedback.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 class Feedback(BaseModel):
     device_id: str = Field(..., min_length=6, max_length=64)
+    threshold_id: str = Field(..., min_length=1)
     commute_time: Literal["morning", "evening"]
     temperature_ok: bool
     wind_speed_ok: bool

--- a/ride_aware_backend/models/ride_history.py
+++ b/ride_aware_backend/models/ride_history.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 
 class RideHistoryEntry(BaseModel):
     device_id: str = Field(..., min_length=6, max_length=64)
+    threshold_id: str = Field(..., min_length=1)
     date: date
     start_time: str
     end_time: str

--- a/ride_aware_backend/models/thresholds.py
+++ b/ride_aware_backend/models/thresholds.py
@@ -1,3 +1,4 @@
+from datetime import date
 from pydantic import BaseModel, Field, condecimal, StringConstraints, ConfigDict
 from typing import Annotated, Optional
 
@@ -27,6 +28,8 @@ class CommuteWindows(BaseModel):
 
 class Thresholds(BaseModel):
     device_id: str = Field(..., min_length=6, max_length=64)
+    date: date
+    start_time: TimeStr
     weather_limits: WeatherLimits
     office_location: OfficeLocation
     commute_windows: Optional[CommuteWindows] = None

--- a/ride_aware_backend/routes/feedback.py
+++ b/ride_aware_backend/routes/feedback.py
@@ -10,5 +10,9 @@ router = APIRouter(prefix="/feedback", tags=["Feedback"])
 @router.post("", include_in_schema=False)
 @router.post("/")
 async def submit_feedback(feedback: Feedback):
-    logger.info("Received feedback for device %s", feedback.device_id)
+    logger.info(
+        "Received feedback for device %s on threshold %s",
+        feedback.device_id,
+        feedback.threshold_id,
+    )
     return await save_feedback(feedback)

--- a/ride_aware_backend/routes/thresholds.py
+++ b/ride_aware_backend/routes/thresholds.py
@@ -11,12 +11,19 @@ router = APIRouter(prefix="/thresholds", tags=["Thresholds"])
 @router.post("", include_in_schema=False)
 @router.post("/")
 async def set_threshold(threshold: Thresholds):
-    logger.info("Setting thresholds for device %s", threshold.device_id)
+    logger.info(
+        "Setting thresholds for device %s on %s at %s",
+        threshold.device_id,
+        threshold.date,
+        threshold.start_time,
+    )
     return await upsert_threshold(threshold)
 
 
-@router.get("/{device_id}")
-async def fetch_threshold(device_id: str):
-    logger.info("Fetching thresholds for device %s", device_id)
-    return await get_thresholds(device_id)
+@router.get("/{device_id}/{date}/{start_time}")
+async def fetch_threshold(device_id: str, date: str, start_time: str):
+    logger.info(
+        "Fetching thresholds for device %s on %s at %s", device_id, date, start_time
+    )
+    return await get_thresholds(device_id, date, start_time)
 

--- a/ride_aware_backend/services/db.py
+++ b/ride_aware_backend/services/db.py
@@ -13,3 +13,19 @@ routes_collection = db["routes"]
 fcm_tokens_collection = db["fcm_tokens"]
 feedback_collection = db["feedback"]
 ride_history_collection = db["ride_history"]
+
+
+async def init_db() -> None:
+    """Initialize database indexes."""
+    await thresholds_collection.create_index(
+        [
+            ("device_id", 1),
+            ("date", 1),
+            ("start_time", 1),
+        ],
+        unique=True,
+    )
+    await feedback_collection.create_index("threshold_id", unique=True)
+    await ride_history_collection.create_index(
+        [("date", 1), ("threshold_id", 1)], unique=True
+    )

--- a/ride_aware_backend/tests/controllers/test_threshold_controller.py
+++ b/ride_aware_backend/tests/controllers/test_threshold_controller.py
@@ -1,5 +1,7 @@
 import asyncio
+import asyncio
 import pytest
+from datetime import date
 from unittest.mock import AsyncMock
 
 from controllers import threshold_controller
@@ -9,6 +11,8 @@ from models.thresholds import Thresholds, WeatherLimits, OfficeLocation
 def test_upsert_threshold(monkeypatch):
     thresholds = Thresholds(
         device_id="device123",
+        date=date(2024, 1, 1),
+        start_time="08:00",
         weather_limits=WeatherLimits(
             max_wind_speed=10,
             max_rain_intensity=5,
@@ -32,6 +36,8 @@ def test_upsert_threshold(monkeypatch):
 def test_get_thresholds(monkeypatch):
     doc = {
         "device_id": "device123",
+        "date": "2024-01-01",
+        "start_time": "08:00",
         "weather_limits": {
             "max_wind_speed": 10,
             "max_rain_intensity": 5,
@@ -48,7 +54,9 @@ def test_get_thresholds(monkeypatch):
     }
     collection = type("C", (), {"find_one": AsyncMock(return_value=dict(doc))})()
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
-    result = asyncio.run(threshold_controller.get_thresholds("device123"))
+    result = asyncio.run(
+        threshold_controller.get_thresholds("device123", "2024-01-01", "08:00")
+    )
     assert result["device_id"] == "device123"
 
 
@@ -56,4 +64,6 @@ def test_get_thresholds_not_found(monkeypatch):
     collection = type("C", (), {"find_one": AsyncMock(return_value=None)})()
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
     with pytest.raises(threshold_controller.HTTPException):
-        asyncio.run(threshold_controller.get_thresholds("device123"))
+        asyncio.run(
+            threshold_controller.get_thresholds("device123", "2024-01-01", "08:00")
+        )

--- a/ride_aware_backend/tests/models/test_models.py
+++ b/ride_aware_backend/tests/models/test_models.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 
 from models.fcm import FCMDeviceModel
 from models.route import RouteModel, GeoPoint
+from datetime import date
 from models.thresholds import Thresholds, WeatherLimits, OfficeLocation
 
 
@@ -41,6 +42,8 @@ def test_route_model_invalid_latitude():
 def test_thresholds_model_valid():
     thresholds = Thresholds(
         device_id="device123",
+        date=date(2024, 1, 1),
+        start_time="08:00",
         weather_limits=WeatherLimits(
             max_wind_speed=10,
             max_rain_intensity=5,
@@ -60,6 +63,8 @@ def test_thresholds_model_invalid_device_id():
     with pytest.raises(ValidationError):
         Thresholds(
             device_id="dev",
+            date=date(2024, 1, 1),
+            start_time="08:00",
             weather_limits=WeatherLimits(
                 max_wind_speed=10,
                 max_rain_intensity=5,


### PR DESCRIPTION
## Summary
- track thresholds per ride using device, date, and start time
- link ride feedback and history entries to specific threshold records
- ensure collections have proper unique indexes on identifiers

## Testing
- `cd ride_aware_backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68925922adc483288ae0c54e9d7433bf