### PR TITLE
Fix unique index creation for feedback collection

### DIFF
--- a/ride_aware_backend/services/db.py
+++ b/ride_aware_backend/services/db.py
@@ -25,7 +25,11 @@ async def init_db() -> None:
         ],
         unique=True,
     )
-    await feedback_collection.create_index("threshold_id", unique=True)
+    await feedback_collection.create_index(
+        "threshold_id",
+        unique=True,
+        partialFilterExpression={"threshold_id": {"$exists": True, "$ne": None}},
+    )
     await ride_history_collection.create_index(
         [("date", 1), ("threshold_id", 1)], unique=True
     )


### PR DESCRIPTION
## Summary
- exclude null threshold_id values when creating unique index on feedback collection to prevent DuplicateKeyError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892629fd7408328a23670c9ce80735b