### PR TITLE
Align threshold validation between backend and frontend

### DIFF
--- a/ride_aware_backend/models/thresholds.py
+++ b/ride_aware_backend/models/thresholds.py
@@ -1,10 +1,12 @@
-from datetime import date
 from pydantic import BaseModel, Field, condecimal, StringConstraints, ConfigDict
 from typing import Annotated, Optional
 
 TimeStr = Annotated[str, StringConstraints(pattern=r"^\d{2}:\d{2}$")]
+DateStr = Annotated[str, StringConstraints(pattern=r"^\d{4}-\d{2}-\d{2}$")]
 
 class WeatherLimits(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     max_wind_speed: condecimal(gt=0, le=200)
     max_rain_intensity: condecimal(ge=0, le=50)
     max_humidity: condecimal(gt=0, le=100)
@@ -17,18 +19,22 @@ class WeatherLimits(BaseModel):
     max_uv_index: Optional[condecimal(gt=0, le=11)] = None
 
 class OfficeLocation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     latitude: condecimal(gt=-90, le=90, decimal_places=6)
     longitude: condecimal(gt=-180, le=180, decimal_places=6)
 
 class CommuteWindows(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
     start: TimeStr = Field(alias="morning")
     end: TimeStr = Field(alias="evening")
 
 
 class Thresholds(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     device_id: str = Field(..., min_length=6, max_length=64)
-    date: date
+    date: DateStr
     start_time: TimeStr
     weather_limits: WeatherLimits
     office_location: OfficeLocation

--- a/ride_aware_backend/routes/thresholds.py
+++ b/ride_aware_backend/routes/thresholds.py
@@ -1,5 +1,5 @@
 import logging
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from models.thresholds import Thresholds
 from controllers.threshold_controller import upsert_threshold, get_thresholds
 
@@ -10,7 +10,9 @@ router = APIRouter(prefix="/thresholds", tags=["Thresholds"])
 
 @router.post("", include_in_schema=False)
 @router.post("/")
-async def set_threshold(threshold: Thresholds):
+async def set_threshold(threshold: Thresholds, request: Request):
+    body = await request.json()
+    logger.debug("Incoming payload: %s", body)
     logger.info(
         "Setting thresholds for device %s on %s at %s",
         threshold.device_id,

--- a/ride_aware_backend/tests/controllers/test_threshold_controller.py
+++ b/ride_aware_backend/tests/controllers/test_threshold_controller.py
@@ -1,7 +1,5 @@
 import asyncio
-import asyncio
 import pytest
-from datetime import date
 from unittest.mock import AsyncMock
 
 from controllers import threshold_controller
@@ -11,7 +9,7 @@ from models.thresholds import Thresholds, WeatherLimits, OfficeLocation
 def test_upsert_threshold(monkeypatch):
     thresholds = Thresholds(
         device_id="device123",
-        date=date(2024, 1, 1),
+        date="2024-01-01",
         start_time="08:00",
         weather_limits=WeatherLimits(
             max_wind_speed=10,

--- a/ride_aware_backend/tests/models/test_models.py
+++ b/ride_aware_backend/tests/models/test_models.py
@@ -3,7 +3,6 @@ from pydantic import ValidationError
 
 from models.fcm import FCMDeviceModel
 from models.route import RouteModel, GeoPoint
-from datetime import date
 from models.thresholds import Thresholds, WeatherLimits, OfficeLocation
 
 
@@ -42,7 +41,7 @@ def test_route_model_invalid_latitude():
 def test_thresholds_model_valid():
     thresholds = Thresholds(
         device_id="device123",
-        date=date(2024, 1, 1),
+        date="2024-01-01",
         start_time="08:00",
         weather_limits=WeatherLimits(
             max_wind_speed=10,
@@ -63,7 +62,7 @@ def test_thresholds_model_invalid_device_id():
     with pytest.raises(ValidationError):
         Thresholds(
             device_id="dev",
-            date=date(2024, 1, 1),
+            date="2024-01-01",
             start_time="08:00",
             weather_limits=WeatherLimits(
                 max_wind_speed=10,

--- a/ride_aware_backend/tests/routes/test_threshold_route.py
+++ b/ride_aware_backend/tests/routes/test_threshold_route.py
@@ -1,0 +1,49 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from routes import thresholds as threshold_route
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_upsert(monkeypatch):
+    async def fake_upsert_threshold(threshold):
+        return {"status": "ok"}
+
+    monkeypatch.setattr(threshold_route, "upsert_threshold", fake_upsert_threshold)
+
+
+def test_set_threshold_success():
+    payload = {
+        "device_id": "device123",
+        "date": "2024-01-01",
+        "start_time": "08:00",
+        "weather_limits": {
+            "max_wind_speed": 10,
+            "max_rain_intensity": 5,
+            "max_humidity": 80,
+            "min_temperature": 0,
+            "max_temperature": 35,
+            "headwind_sensitivity": 20,
+            "crosswind_sensitivity": 15,
+        },
+        "office_location": {"latitude": 0, "longitude": 0},
+        "commute_windows": {"morning": "07:30", "evening": "17:30"},
+    }
+    response = client.post("/thresholds", json=payload)
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_set_threshold_validation_error():
+    payload = {
+        "device_id": "device123",
+        "date": "invalid-date",
+        "start_time": "8",
+        "weather_limits": {},
+        "office_location": {"latitude": 0, "longitude": 0},
+    }
+    response = client.post("/thresholds", json=payload)
+    assert response.status_code == 422

--- a/ride_aware_frontend/lib/services/api_service.dart
+++ b/ride_aware_frontend/lib/services/api_service.dart
@@ -24,11 +24,20 @@ class ApiService {
         );
       }
 
+      if (!preferences.isValid) {
+        if (kDebugMode) {
+          print('❌ Invalid preferences: ${jsonEncode(preferences.toJson())}');
+        }
+        throw Exception('Invalid threshold values');
+      }
+
       final requestBody = {
-        ...preferences.toJson(),
         'device_id': deviceId,
         'date': DateTime.now().toIso8601String().split('T').first,
         'start_time': preferences.commuteWindows.start,
+        'weather_limits': preferences.weatherLimits.toJson(),
+        'office_location': preferences.officeLocation.toJson(),
+        'commute_windows': preferences.commuteWindows.toJson(),
       };
 
       // Debug messages


### PR DESCRIPTION
## Summary
- enforce strict formats in Thresholds models and forbid unknown fields
- log raw `/thresholds` request payloads
- validate and shape threshold submissions on Flutter client and add route tests

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892715ff0348328994dacdf2c708cc5