### PR TITLE
Replace morning/evening with start/end commute and add threshold end time

### DIFF
--- a/ride_aware_backend/controllers/threshold_controller.py
+++ b/ride_aware_backend/controllers/threshold_controller.py
@@ -12,14 +12,20 @@ async def upsert_threshold(threshold: Thresholds) -> dict:
     device_id = data["device_id"]
     date = data["date"]
     start_time = data["start_time"]
+    end_time = data["end_time"]
     logger.info(
-        "Upserting thresholds for device %s on %s at %s", device_id, date, start_time
+        "Upserting thresholds for device %s on %s from %s to %s",
+        device_id,
+        date,
+        start_time,
+        end_time,
     )
 
     filter_doc = {
         "device_id": device_id,
         "date": date,
         "start_time": start_time,
+        "end_time": end_time,
     }
 
     result = await thresholds_collection.update_one(
@@ -28,10 +34,11 @@ async def upsert_threshold(threshold: Thresholds) -> dict:
         upsert=True,
     )
     logger.info(
-        "Thresholds upserted for device %s on %s at %s",
+        "Thresholds upserted for device %s on %s from %s to %s",
         device_id,
         date,
         start_time,
+        end_time,
     )
     logger.debug(
         "Upsert result for %s: modified=%s upserted_id=%s",
@@ -44,25 +51,36 @@ async def upsert_threshold(threshold: Thresholds) -> dict:
         "device_id": device_id,
         "date": date,
         "start_time": start_time,
+        "end_time": end_time,
         "status": "ok",
         "modified_count": getattr(result, "modified_count", None),
         "upserted_id": str(getattr(result, "upserted_id", "")) or None,
     }
 
 
-async def get_thresholds(device_id: str, date: str, start_time: str) -> dict:
+async def get_thresholds(device_id: str, date: str, start_time: str, end_time: str) -> dict:
     logger.info(
-        "Retrieving thresholds for device %s on %s at %s", device_id, date, start_time
+        "Retrieving thresholds for device %s on %s from %s to %s",
+        device_id,
+        date,
+        start_time,
+        end_time,
     )
     doc = await thresholds_collection.find_one(
-        {"device_id": device_id, "date": date, "start_time": start_time}
+        {
+            "device_id": device_id,
+            "date": date,
+            "start_time": start_time,
+            "end_time": end_time,
+        }
     )
     if not doc:
         logger.warning(
-            "Thresholds not found for device %s on %s at %s",
+            "Thresholds not found for device %s on %s from %s to %s",
             device_id,
             date,
             start_time,
+            end_time,
         )
         raise HTTPException(status_code=404, detail="Thresholds not found")
 

--- a/ride_aware_backend/models/feedback.py
+++ b/ride_aware_backend/models/feedback.py
@@ -5,7 +5,7 @@ from typing import Literal
 class Feedback(BaseModel):
     device_id: str = Field(..., min_length=6, max_length=64)
     threshold_id: str = Field(..., min_length=1)
-    commute_time: Literal["morning", "evening"]
+    commute: Literal["start", "end"]
     temperature_ok: bool
     wind_speed_ok: bool
     headwind_ok: bool

--- a/ride_aware_backend/models/thresholds.py
+++ b/ride_aware_backend/models/thresholds.py
@@ -24,11 +24,6 @@ class OfficeLocation(BaseModel):
     latitude: condecimal(gt=-90, le=90, decimal_places=6)
     longitude: condecimal(gt=-180, le=180, decimal_places=6)
 
-class CommuteWindows(BaseModel):
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
-    start: TimeStr = Field(alias="morning")
-    end: TimeStr = Field(alias="evening")
-
 
 class Thresholds(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -36,6 +31,6 @@ class Thresholds(BaseModel):
     device_id: str = Field(..., min_length=6, max_length=64)
     date: DateStr
     start_time: TimeStr
+    end_time: TimeStr
     weather_limits: WeatherLimits
     office_location: OfficeLocation
-    commute_windows: Optional[CommuteWindows] = None

--- a/ride_aware_backend/routes/thresholds.py
+++ b/ride_aware_backend/routes/thresholds.py
@@ -14,18 +14,23 @@ async def set_threshold(threshold: Thresholds, request: Request):
     body = await request.json()
     logger.debug("Incoming payload: %s", body)
     logger.info(
-        "Setting thresholds for device %s on %s at %s",
+        "Setting thresholds for device %s on %s from %s to %s",
         threshold.device_id,
         threshold.date,
         threshold.start_time,
+        threshold.end_time,
     )
     return await upsert_threshold(threshold)
 
 
-@router.get("/{device_id}/{date}/{start_time}")
-async def fetch_threshold(device_id: str, date: str, start_time: str):
+@router.get("/{device_id}/{date}/{start_time}/{end_time}")
+async def fetch_threshold(device_id: str, date: str, start_time: str, end_time: str):
     logger.info(
-        "Fetching thresholds for device %s on %s at %s", device_id, date, start_time
+        "Fetching thresholds for device %s on %s from %s to %s",
+        device_id,
+        date,
+        start_time,
+        end_time,
     )
-    return await get_thresholds(device_id, date, start_time)
+    return await get_thresholds(device_id, date, start_time, end_time)
 

--- a/ride_aware_backend/services/commute_status_service.py
+++ b/ride_aware_backend/services/commute_status_service.py
@@ -28,16 +28,8 @@ async def get_commute_status(device_id: str) -> dict:
     lon = float(thresholds.office_location.longitude)
 
     today = datetime.now().date()
-    if thresholds.commute_windows:
-        start_dt = datetime.combine(
-            today, parse_time(thresholds.commute_windows.start)
-        )
-        end_dt = datetime.combine(
-            today, parse_time(thresholds.commute_windows.end)
-        )
-    else:
-        start_dt = datetime.combine(today, parse_time("08:00"))
-        end_dt = datetime.combine(today, parse_time("17:00"))
+    start_dt = datetime.combine(today, parse_time(thresholds.start_time))
+    end_dt = datetime.combine(today, parse_time(thresholds.end_time))
 
     start_weather = get_hourly_forecast(lat, lon, start_dt)
     end_weather = get_hourly_forecast(lat, lon, end_dt)
@@ -57,12 +49,11 @@ async def get_commute_status(device_id: str) -> dict:
 
     return {
         "device_id": device_id,
-        # Keep response keys for backward compatibility
-        "morning_status": {
+        "start_status": {
             "exceeded": start_exceeded,
             "weather_snapshot": start_weather,
         },
-        "evening_status": {
+        "end_status": {
             "exceeded": end_exceeded,
             "weather_snapshot": end_weather,
         },

--- a/ride_aware_backend/tests/controllers/test_threshold_controller.py
+++ b/ride_aware_backend/tests/controllers/test_threshold_controller.py
@@ -11,6 +11,7 @@ def test_upsert_threshold(monkeypatch):
         device_id="device123",
         date="2024-01-01",
         start_time="08:00",
+        end_time="17:00",
         weather_limits=WeatherLimits(
             max_wind_speed=10,
             max_rain_intensity=5,
@@ -36,6 +37,7 @@ def test_get_thresholds(monkeypatch):
         "device_id": "device123",
         "date": "2024-01-01",
         "start_time": "08:00",
+        "end_time": "17:00",
         "weather_limits": {
             "max_wind_speed": 10,
             "max_rain_intensity": 5,
@@ -53,7 +55,7 @@ def test_get_thresholds(monkeypatch):
     collection = type("C", (), {"find_one": AsyncMock(return_value=dict(doc))})()
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
     result = asyncio.run(
-        threshold_controller.get_thresholds("device123", "2024-01-01", "08:00")
+        threshold_controller.get_thresholds("device123", "2024-01-01", "08:00", "17:00")
     )
     assert result["device_id"] == "device123"
 
@@ -63,5 +65,7 @@ def test_get_thresholds_not_found(monkeypatch):
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
     with pytest.raises(threshold_controller.HTTPException):
         asyncio.run(
-            threshold_controller.get_thresholds("device123", "2024-01-01", "08:00")
+            threshold_controller.get_thresholds(
+                "device123", "2024-01-01", "08:00", "17:00"
+            )
         )

--- a/ride_aware_backend/tests/models/test_models.py
+++ b/ride_aware_backend/tests/models/test_models.py
@@ -43,6 +43,7 @@ def test_thresholds_model_valid():
         device_id="device123",
         date="2024-01-01",
         start_time="08:00",
+        end_time="17:00",
         weather_limits=WeatherLimits(
             max_wind_speed=10,
             max_rain_intensity=5,
@@ -64,6 +65,7 @@ def test_thresholds_model_invalid_device_id():
             device_id="dev",
             date="2024-01-01",
             start_time="08:00",
+            end_time="17:00",
             weather_limits=WeatherLimits(
                 max_wind_speed=10,
                 max_rain_intensity=5,

--- a/ride_aware_backend/tests/routes/test_threshold_route.py
+++ b/ride_aware_backend/tests/routes/test_threshold_route.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest
 from fastapi.testclient import TestClient
 
 from main import app
@@ -20,6 +21,7 @@ def test_set_threshold_success():
         "device_id": "device123",
         "date": "2024-01-01",
         "start_time": "08:00",
+        "end_time": "17:00",
         "weather_limits": {
             "max_wind_speed": 10,
             "max_rain_intensity": 5,
@@ -30,7 +32,6 @@ def test_set_threshold_success():
             "crosswind_sensitivity": 15,
         },
         "office_location": {"latitude": 0, "longitude": 0},
-        "commute_windows": {"morning": "07:30", "evening": "17:30"},
     }
     response = client.post("/thresholds", json=payload)
     assert response.status_code == 200

--- a/ride_aware_frontend/lib/models/commute_status.dart
+++ b/ride_aware_frontend/lib/models/commute_status.dart
@@ -1,22 +1,22 @@
 class CommuteStatusResponse {
   final String deviceId;
-  final CommuteStatusData morning;
-  final CommuteStatusData evening;
+  final CommuteStatusData start;
+  final CommuteStatusData end;
 
   const CommuteStatusResponse({
     required this.deviceId,
-    required this.morning,
-    required this.evening,
+    required this.start,
+    required this.end,
   });
 
   factory CommuteStatusResponse.fromJson(Map<String, dynamic> json) {
     return CommuteStatusResponse(
       deviceId: json['device_id'] as String? ?? '',
-      morning: CommuteStatusData.fromJson(
-        json['morning_status'] as Map<String, dynamic>? ?? {},
+      start: CommuteStatusData.fromJson(
+        json['start_status'] as Map<String, dynamic>? ?? {},
       ),
-      evening: CommuteStatusData.fromJson(
-        json['evening_status'] as Map<String, dynamic>? ?? {},
+      end: CommuteStatusData.fromJson(
+        json['end_status'] as Map<String, dynamic>? ?? {},
       ),
     );
   }

--- a/ride_aware_frontend/lib/models/user_preferences.dart
+++ b/ride_aware_frontend/lib/models/user_preferences.dart
@@ -32,7 +32,10 @@ class UserPreferences {
         json['environmental_risk'] ?? {},
       ),
       officeLocation: OfficeLocation.fromJson(json['office_location'] ?? {}),
-      commuteWindows: CommuteWindows.fromJson(json['commute_windows'] ?? {}),
+      commuteWindows: CommuteWindows.fromJson({
+        'start': json['start_time'] ?? '07:30',
+        'end': json['end_time'] ?? '17:30',
+      }),
     );
   }
 
@@ -42,7 +45,8 @@ class UserPreferences {
       'weather_limits': weatherLimits.toJson(),
       'environmental_risk': environmentalRisk.toJson(),
       'office_location': officeLocation.toJson(),
-      'commute_windows': commuteWindows.toJson(),
+      'start_time': commuteWindows.start,
+      'end_time': commuteWindows.end,
     };
   }
 
@@ -383,14 +387,13 @@ class CommuteWindows {
 
   factory CommuteWindows.fromJson(Map<String, dynamic> json) {
     return CommuteWindows(
-      start: json['morning'] ?? '07:30',
-      end: json['evening'] ?? '17:30',
+      start: json['start'] ?? '07:30',
+      end: json['end'] ?? '17:30',
     );
   }
 
   Map<String, dynamic> toJson() {
-    // Keep existing JSON keys for backwards compatibility
-    return {'morning': start, 'evening': end};
+    return {'start': start, 'end': end};
   }
 
   CommuteWindows copyWith({String? start, String? end}) {

--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -24,7 +24,7 @@ class _DashboardScreenState extends State<DashboardScreen>
 
   UserPreferences? _prefs;
   String _feedbackSummary = 'You did a great job!';
-  bool _eveningFeedbackGiven = false;
+  bool _endFeedbackGiven = false;
   DateTime _lastReset = DateTime.now();
   bool _feedbackNotificationShown = false;
   bool _historySaved = false;
@@ -44,10 +44,10 @@ class _DashboardScreenState extends State<DashboardScreen>
 
   Future<void> _loadPrefs() async {
     final p = await _prefsService.loadPreferences();
-    final feedbackGiven = await _prefsService.isEveningFeedbackGivenToday();
+    final feedbackGiven = await _prefsService.isEndFeedbackGivenToday();
     setState(() {
       _prefs = p;
-      _eveningFeedbackGiven = feedbackGiven;
+      _endFeedbackGiven = feedbackGiven;
     });
   }
 
@@ -62,10 +62,10 @@ class _DashboardScreenState extends State<DashboardScreen>
     if (now.year != _lastReset.year ||
         now.month != _lastReset.month ||
         now.day != _lastReset.day) {
-      _eveningFeedbackGiven = false;
+      _endFeedbackGiven = false;
       _feedbackSummary = 'You did a great job!';
       _lastReset = now;
-      _prefsService.clearEveningFeedbackGiven();
+      _prefsService.clearEndFeedbackGiven();
       _feedbackNotificationShown = false;
       _historySaved = false;
     }
@@ -120,7 +120,7 @@ class _DashboardScreenState extends State<DashboardScreen>
     _resetFlagsIfNewDay();
     _saveRideHistoryIfCompleted();
     final showFeedback = _shouldShowFeedbackCard();
-    if (showFeedback && !_eveningFeedbackGiven && !_feedbackNotificationShown) {
+    if (showFeedback && !_endFeedbackGiven && !_feedbackNotificationShown) {
       _notificationService.showFeedbackNotification();
       _feedbackNotificationShown = true;
     }
@@ -177,33 +177,32 @@ class _DashboardScreenState extends State<DashboardScreen>
             // Commute Feedback Card
             if (showFeedback)
               Card(
-                color: _eveningFeedbackGiven ? Colors.grey : Colors.red,
+                color: _endFeedbackGiven ? Colors.grey : Colors.red,
                 margin: const EdgeInsets.all(16),
                 child: ListTile(
                   leading: const Icon(Icons.feedback, color: Colors.white),
                   title: Text(
-                    _eveningFeedbackGiven
+                    _endFeedbackGiven
                         ? 'Feedback submitted for your last ride'
                         : 'Feedback available for your last ride',
                   ),
-                  onTap: _eveningFeedbackGiven
+                  onTap: _endFeedbackGiven
                       ? null
                       : () async {
                           final result = await Navigator.push(
                             context,
                             MaterialPageRoute(
                               builder: (_) => const PostRideFeedbackScreen(
-                                commuteTime: 'evening',
+                                commute: 'end',
                               ),
                             ),
                           );
                           if (result != null) {
                             setState(() {
                               _feedbackSummary = result['summary'] as String;
-                              _eveningFeedbackGiven = true;
+                              _endFeedbackGiven = true;
                             });
-                            _prefsService
-                                .setEveningFeedbackGiven(DateTime.now());
+                            _prefsService.setEndFeedbackGiven(DateTime.now());
                           }
                         },
                 ),

--- a/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
+++ b/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
@@ -3,8 +3,8 @@ import '../services/commute_status_service.dart';
 import '../services/api_service.dart';
 
 class PostRideFeedbackScreen extends StatefulWidget {
-  final String commuteTime; // 'morning' or 'evening'
-  const PostRideFeedbackScreen({super.key, required this.commuteTime});
+  final String commute; // 'start' or 'end'
+  const PostRideFeedbackScreen({super.key, required this.commute});
 
   @override
   State<PostRideFeedbackScreen> createState() => _PostRideFeedbackScreenState();
@@ -31,9 +31,7 @@ class _PostRideFeedbackScreenState extends State<PostRideFeedbackScreen> {
 
   Future<List<String>> _loadViolations() async {
     final status = await _statusService.getCommuteStatus();
-    final data = widget.commuteTime == 'morning'
-        ? status.morning
-        : status.evening;
+    final data = widget.commute == 'start' ? status.start : status.end;
     return data.violations;
   }
 
@@ -136,7 +134,7 @@ class _PostRideFeedbackScreenState extends State<PostRideFeedbackScreen> {
 
   Future<void> _submit() async {
     final payload = {
-      'commute_time': widget.commuteTime,
+      'commute': widget.commute,
       'temperature_ok': temperatureOk,
       'wind_speed_ok': windSpeedOk,
       'headwind_ok': headwindOk,
@@ -150,7 +148,7 @@ class _PostRideFeedbackScreenState extends State<PostRideFeedbackScreen> {
       if (context.mounted) {
         Navigator.pop(context, {
           'summary': summary,
-          'commute': widget.commuteTime,
+          'commute': widget.commute,
         });
       }
     } catch (e) {

--- a/ride_aware_frontend/lib/services/api_service.dart
+++ b/ride_aware_frontend/lib/services/api_service.dart
@@ -35,9 +35,9 @@ class ApiService {
         'device_id': deviceId,
         'date': DateTime.now().toIso8601String().split('T').first,
         'start_time': preferences.commuteWindows.start,
+        'end_time': preferences.commuteWindows.end,
         'weather_limits': preferences.weatherLimits.toJson(),
         'office_location': preferences.officeLocation.toJson(),
-        'commute_windows': preferences.commuteWindows.toJson(),
       };
 
       // Debug messages

--- a/ride_aware_frontend/lib/services/preferences_service.dart
+++ b/ride_aware_frontend/lib/services/preferences_service.dart
@@ -8,7 +8,7 @@ class PreferencesService {
   static const String _preferencesKey = 'user_preferences';
   static const String _thresholdsSetKey = 'thresholdsSet';
   static const String _prefsVersionKey = 'prefsVersion';
-  static const String _lastEveningFeedbackKey = 'lastEveningFeedback';
+  static const String _lastEndFeedbackKey = 'lastEndFeedback';
   static const String _currentThresholdIdKey = 'currentThresholdId';
 
   final DeviceIdService _deviceIdService = DeviceIdService();
@@ -92,15 +92,14 @@ class PreferencesService {
     return prefs.containsKey(_preferencesKey);
   }
 
-  Future<void> setEveningFeedbackGiven(DateTime date) async {
+  Future<void> setEndFeedbackGiven(DateTime date) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(
-        _lastEveningFeedbackKey, date.toIso8601String());
+    await prefs.setString(_lastEndFeedbackKey, date.toIso8601String());
   }
 
-  Future<bool> isEveningFeedbackGivenToday() async {
+  Future<bool> isEndFeedbackGivenToday() async {
     final prefs = await SharedPreferences.getInstance();
-    final dateStr = prefs.getString(_lastEveningFeedbackKey);
+    final dateStr = prefs.getString(_lastEndFeedbackKey);
     if (dateStr == null) return false;
     final date = DateTime.tryParse(dateStr);
     if (date == null) return false;
@@ -110,9 +109,9 @@ class PreferencesService {
         now.day == date.day;
   }
 
-  Future<void> clearEveningFeedbackGiven() async {
+  Future<void> clearEndFeedbackGiven() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_lastEveningFeedbackKey);
+    await prefs.remove(_lastEndFeedbackKey);
   }
 
   Future<void> saveCurrentThresholdId(String thresholdId) async {


### PR DESCRIPTION
## Summary
- add `end_time` to thresholds and remove commute windows, returning start and end statuses
- switch feedback and frontend components from morning/evening to start/end commute terminology
- update preferences and API calls to store and submit start and end times

## Testing
- `pytest`
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6892784b94b48328b2ba330c510f3470