### PR TITLE
Handle ride timezones and feedback expiry

### DIFF
--- a/ride_aware_backend/controllers/feedback_controller.py
+++ b/ride_aware_backend/controllers/feedback_controller.py
@@ -1,6 +1,6 @@
 import logging
 from models.feedback import Feedback
-from services.db import feedback_collection
+from services.db import feedback_collection, ride_history_collection
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,11 @@ async def save_feedback(feedback: Feedback) -> dict:
     result = await feedback_collection.update_one(
         {"threshold_id": threshold_id}, {"$set": data}, upsert=True
     )
+    if data.get("summary"):
+        await ride_history_collection.update_one(
+            {"device_id": device_id, "threshold_id": threshold_id},
+            {"$set": {"feedback": data["summary"]}},
+        )
     logger.debug(
         "Feedback upserted for threshold %s: modified=%s upserted_id=%s", threshold_id,
         getattr(result, "modified_count", None), getattr(result, "upserted_id", None)

--- a/ride_aware_backend/models/feedback.py
+++ b/ride_aware_backend/models/feedback.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Literal
+from typing import Literal, Optional
 
 
 class Feedback(BaseModel):
@@ -12,3 +12,4 @@ class Feedback(BaseModel):
     crosswind_ok: bool
     precipitation_ok: bool
     humidity_ok: bool
+    summary: Optional[str] = None

--- a/ride_aware_frontend/lib/models/ride_history_entry.dart
+++ b/ride_aware_frontend/lib/models/ride_history_entry.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'user_preferences.dart';
 
 class RideHistoryEntry {
   final String thresholdId;
@@ -20,11 +21,12 @@ class RideHistoryEntry {
   });
 
   factory RideHistoryEntry.fromJson(Map<String, dynamic> json) {
+    final cw = CommuteWindows.defaultValues();
     return RideHistoryEntry(
       thresholdId: json['threshold_id'] as String,
-      date: DateTime.parse(json['date'] as String),
-      startTime: _parseTime(json['start_time'] as String),
-      endTime: _parseTime(json['end_time'] as String),
+      date: DateTime.parse(json['date'] as String).toLocal(),
+      startTime: cw.utcToLocalTimeOfDay(json['start_time'] as String),
+      endTime: cw.utcToLocalTimeOfDay(json['end_time'] as String),
       status: json['status'] as String,
       summary: Map<String, dynamic>.from(json['summary'] as Map),
       feedback: json['feedback'] as String?,
@@ -33,19 +35,13 @@ class RideHistoryEntry {
 
   Map<String, dynamic> toJson() => {
         'threshold_id': thresholdId,
-        'date': date.toIso8601String().split('T').first,
-        'start_time': _formatTime(startTime),
-        'end_time': _formatTime(endTime),
+        'date': date.toUtc().toIso8601String().split('T').first,
+        'start_time': CommuteWindows.localTimeOfDayToUtc(startTime),
+        'end_time': CommuteWindows.localTimeOfDayToUtc(endTime),
         'status': status,
         'summary': summary,
         if (feedback != null) 'feedback': feedback,
       };
 
-  static TimeOfDay _parseTime(String value) {
-    final parts = value.split(':');
-    return TimeOfDay(hour: int.parse(parts[0]), minute: int.parse(parts[1]));
-  }
-
-  static String _formatTime(TimeOfDay t) =>
-      '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+  // No additional helpers needed; conversions handled by [CommuteWindows].
 }

--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -83,8 +83,8 @@ class _DashboardScreenState extends State<DashboardScreen>
     final now = DateTime.now();
     final end = _prefs!.commuteWindows.endLocal;
     final todayEnd = DateTime(now.year, now.month, now.day, end.hour, end.minute);
-    final feedbackTime = todayEnd.add(const Duration(hours: 1));
-    return now.isAfter(feedbackTime);
+    final expiry = todayEnd.add(const Duration(hours: 1));
+    return now.isAfter(todayEnd) && now.isBefore(expiry);
   }
 
   Future<void> _saveRideHistoryIfCompleted() async {
@@ -100,12 +100,12 @@ class _DashboardScreenState extends State<DashboardScreen>
 
     final entry = RideHistoryEntry(
       thresholdId: thresholdId,
-      date: DateTime(now.year, now.month, now.day),
+      date: DateTime.now().toUtc(),
       startTime: _prefs!.commuteWindows.startLocal,
       endTime: _prefs!.commuteWindows.endLocal,
       status: result.status,
       summary: result.summary,
-      feedback: _feedbackSummary,
+      feedback: null,
     );
     try {
       await _apiService.saveRideHistoryEntry(entry);

--- a/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
+++ b/ride_aware_frontend/lib/screens/post_ride_feedback_screen.dart
@@ -133,6 +133,7 @@ class _PostRideFeedbackScreenState extends State<PostRideFeedbackScreen> {
   }
 
   Future<void> _submit() async {
+    final summary = _generateSummary();
     final payload = {
       'commute': widget.commute,
       'temperature_ok': temperatureOk,
@@ -141,10 +142,10 @@ class _PostRideFeedbackScreenState extends State<PostRideFeedbackScreen> {
       'crosswind_ok': crosswindOk,
       'precipitation_ok': precipitationOk,
       'humidity_ok': humidityOk,
+      'summary': summary,
     };
     try {
       await _apiService.submitFeedback(payload);
-      final summary = _generateSummary();
       if (context.mounted) {
         Navigator.pop(context, {
           'summary': summary,

--- a/ride_aware_frontend/lib/services/api_service.dart
+++ b/ride_aware_frontend/lib/services/api_service.dart
@@ -33,7 +33,7 @@ class ApiService {
 
       final requestBody = {
         'device_id': deviceId,
-        'date': DateTime.now().toIso8601String().split('T').first,
+        'date': DateTime.now().toUtc().toIso8601String().split('T').first,
         'start_time': preferences.commuteWindows.start,
         'end_time': preferences.commuteWindows.end,
         'weather_limits': preferences.weatherLimits.toJson(),


### PR DESCRIPTION
## Summary
- store ride history times in UTC and convert to local for display
- show post-ride feedback card only for one hour and save history without feedback
- send feedback summary to backend and persist it with ride entry

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892889a8a3c8328a52bfb0392573192