### PR TITLE
feat: create feedback entry on threshold update

### DIFF
--- a/ride_aware_backend/controllers/feedback_controller.py
+++ b/ride_aware_backend/controllers/feedback_controller.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from models.feedback import Feedback
 from services.db import feedback_collection, ride_history_collection
 
@@ -31,3 +32,19 @@ async def save_feedback(feedback: Feedback) -> dict:
         "modified_count": getattr(result, "modified_count", None),
         "upserted_id": str(getattr(result, "upserted_id", "")) or None,
     }
+
+
+async def create_feedback_entry(device_id: str, threshold_id: str) -> None:
+    """Create an empty ride feedback entry for a given threshold.
+
+    This placeholder allows attaching user feedback at a later time while
+    ensuring only one feedback document exists per threshold.
+    """
+    doc = {
+        "device_id": device_id,
+        "threshold_id": threshold_id,
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    await feedback_collection.update_one(
+        {"threshold_id": threshold_id}, {"$setOnInsert": doc}, upsert=True
+    )

--- a/ride_aware_backend/models/feedback.py
+++ b/ride_aware_backend/models/feedback.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel, Field
 from typing import Literal, Optional
 
@@ -12,4 +13,20 @@ class Feedback(BaseModel):
     crosswind_ok: bool
     precipitation_ok: bool
     humidity_ok: bool
+    summary: Optional[str] = None
+
+
+class RideFeedback(BaseModel):
+    """Represents a ride feedback entry awaiting user input."""
+
+    device_id: str = Field(..., min_length=6, max_length=64)
+    threshold_id: str = Field(..., min_length=1)
+    created_at: datetime
+    commute: Optional[Literal["start", "end"]] = None
+    temperature_ok: Optional[bool] = None
+    wind_speed_ok: Optional[bool] = None
+    headwind_ok: Optional[bool] = None
+    crosswind_ok: Optional[bool] = None
+    precipitation_ok: Optional[bool] = None
+    humidity_ok: Optional[bool] = None
     summary: Optional[str] = None


### PR DESCRIPTION
## Summary
- save empty ride feedback entries whenever user thresholds are created or updated
- provide RideFeedback model and update logic to fetch or insert threshold records
- show post-ride feedback card based on commute timing with auto-hide before next ride

## Testing
- `cd ride_aware_app/ride_aware_backend && pytest`
- `cd ride_aware_app/ride_aware_frontend && flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892a76ac8d08323b1b38402ff8b7329