### PR TITLE
Reset ride feedback state for consecutive rides

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -105,6 +105,15 @@ class _DashboardScreenState extends State<DashboardScreen>
     }
     final hideTime = nextStart.subtract(const Duration(minutes: 1));
 
+    // Reset feedback state once the hide window has passed so that
+    // a subsequent route can collect fresh feedback.
+    if (now.isAfter(hideTime) && _endFeedbackGiven) {
+      _endFeedbackGiven = false;
+      _feedbackSummary = 'You did a great job!';
+      _feedbackNotificationShown = false;
+      _prefsService.clearEndFeedbackGiven();
+    }
+
     return now.isAfter(showTime) && now.isBefore(hideTime);
   }
 


### PR DESCRIPTION
## Summary
- reset end-ride feedback flags after the hide window
- allow feedback card to re-enable for the next route

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892b3f5dfa4832380bc1d4feb10ce57