### PR TITLE
Link thresholds with history calendar and refresh dashboard data

### DIFF
--- a/ride_aware_backend/tests/controllers/test_threshold_controller.py
+++ b/ride_aware_backend/tests/controllers/test_threshold_controller.py
@@ -40,13 +40,18 @@ def test_upsert_threshold_insert(monkeypatch):
     )()
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
     create_fb = AsyncMock()
+    create_hist = AsyncMock()
     monkeypatch.setattr(threshold_controller, "create_feedback_entry", create_fb)
+    monkeypatch.setattr(threshold_controller, "create_history_entry", create_hist)
 
     result = asyncio.run(threshold_controller.upsert_threshold(thresholds))
 
     collection.find_one.assert_awaited_once()
     collection.insert_one.assert_awaited_once()
     create_fb.assert_awaited_once_with("device123", "id")
+    create_hist.assert_awaited_once_with(
+        "device123", "id", "2024-01-01", "08:00", "17:00"
+    )
     assert result["threshold_id"] == "id"
     assert result["status"] == "ok"
 
@@ -65,13 +70,18 @@ def test_upsert_threshold_update(monkeypatch):
     )()
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
     create_fb = AsyncMock()
+    create_hist = AsyncMock()
     monkeypatch.setattr(threshold_controller, "create_feedback_entry", create_fb)
+    monkeypatch.setattr(threshold_controller, "create_history_entry", create_hist)
 
     result = asyncio.run(threshold_controller.upsert_threshold(thresholds))
 
     collection.find_one.assert_awaited_once()
     collection.update_one.assert_awaited_once()
     create_fb.assert_awaited_once_with("device123", "existing")
+    create_hist.assert_awaited_once_with(
+        "device123", "existing", "2024-01-01", "08:00", "17:00"
+    )
     assert result["threshold_id"] == "existing"
     assert result["status"] == "ok"
 

--- a/ride_aware_frontend/lib/screens/history_screen.dart
+++ b/ride_aware_frontend/lib/screens/history_screen.dart
@@ -56,6 +56,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
                 _selectedDay = selected;
                 _focusedDay = focused;
               });
+              _loadHistory();
             },
           ),
           const SizedBox(height: 8),

--- a/ride_aware_frontend/lib/services/api_service.dart
+++ b/ride_aware_frontend/lib/services/api_service.dart
@@ -70,7 +70,7 @@ class ApiService {
       String? thresholdId;
       if (response.body.isNotEmpty) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        thresholdId = data['upserted_id'] as String? ?? data['threshold_id'] as String?;
+        thresholdId = data['threshold_id'] as String?;
         if (thresholdId != null) {
           await _preferencesService.saveCurrentThresholdId(thresholdId);
         }


### PR DESCRIPTION
## Summary
- create history placeholder when upserting thresholds so ride history can reference thresholds
- update ride history persistence to upsert by threshold ID
- refresh dashboard history on day selection and rely on consistent `threshold_id`

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892bae568848323bc8ca623f9b49c24