### PR TITLE
Reset feedback state after hide window for consecutive rides

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -106,8 +106,11 @@ class _DashboardScreenState extends State<DashboardScreen>
     final hideTime = nextStart.subtract(const Duration(minutes: 1));
 
     // Reset feedback state once the hide window has passed so that
-    // a subsequent route can collect fresh feedback.
-    if (now.isAfter(hideTime) && _endFeedbackGiven) {
+    // a subsequent route can collect fresh feedback. This clears any
+    // stored flags even if the user dismissed the card without
+    // submitting feedback.
+    if (now.isAfter(hideTime) &&
+        (_endFeedbackGiven || _feedbackNotificationShown)) {
       _endFeedbackGiven = false;
       _feedbackSummary = 'You did a great job!';
       _feedbackNotificationShown = false;


### PR DESCRIPTION
## Summary
- Reset ride feedback flags once the hide window is reached so the card reappears and accepts new input for subsequent rides

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892c10bd4f083238309bcbb6481bfd5