### PR TITLE
Add wind direction endpoint and map visualization

### DIFF
--- a/ride_aware_backend/controllers/wind_controller.py
+++ b/ride_aware_backend/controllers/wind_controller.py
@@ -1,0 +1,12 @@
+import logging
+from typing import List
+
+from models.wind import RouteRequest, WindResult
+from services.wind_service import compute_wind_directions as compute_wind_directions_service
+
+logger = logging.getLogger(__name__)
+
+
+async def compute_wind_directions(req: RouteRequest) -> List[WindResult]:
+    logger.info("Computing wind directions for %s points", len(req.points))
+    return await compute_wind_directions_service(req)

--- a/ride_aware_backend/main.py
+++ b/ride_aware_backend/main.py
@@ -1,6 +1,15 @@
 import logging
 from fastapi import FastAPI
-from routes import thresholds, routes, fcm, commute_status, forecast, feedback, ride_history
+from routes import (
+    thresholds,
+    routes,
+    fcm,
+    commute_status,
+    forecast,
+    feedback,
+    ride_history,
+    wind,
+)
 from services.db import init_db
 
 
@@ -19,6 +28,7 @@ app.include_router(commute_status.router)
 app.include_router(forecast.router)
 app.include_router(feedback.router)
 app.include_router(ride_history.router)
+app.include_router(wind.router)
 
 
 @app.on_event("startup")

--- a/ride_aware_backend/models/wind.py
+++ b/ride_aware_backend/models/wind.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class Coordinate(BaseModel):
+    lat: float = Field(..., description="Latitude in decimal degrees")
+    lon: float = Field(..., description="Longitude in decimal degrees")
+
+
+class RouteRequest(BaseModel):
+    points: List[Coordinate] = Field(
+        ..., description="List of route coordinates (latitude & longitude)"
+    )
+
+
+class WindResult(BaseModel):
+    lat: float
+    lon: float
+    wind_deg: Optional[float] = Field(
+        None, description="Wind direction in degrees (0-360). None if data unavailable"
+    )

--- a/ride_aware_backend/routes/wind.py
+++ b/ride_aware_backend/routes/wind.py
@@ -1,0 +1,16 @@
+import logging
+from typing import List
+
+from fastapi import APIRouter
+
+from controllers.wind_controller import compute_wind_directions
+from models.wind import RouteRequest, WindResult
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["Wind"])
+
+
+@router.post("/wind-directions", response_model=List[WindResult])
+async def wind_directions(route: RouteRequest):
+    logger.info("Wind directions request with %s points", len(route.points))
+    return await compute_wind_directions(route)

--- a/ride_aware_backend/services/wind_service.py
+++ b/ride_aware_backend/services/wind_service.py
@@ -1,0 +1,105 @@
+import logging
+import os
+from datetime import datetime
+from math import radians, sin, cos, sqrt, asin
+from typing import List, Optional
+
+import httpx
+
+from models.wind import Coordinate, RouteRequest, WindResult
+from services.db import db
+
+logger = logging.getLogger(__name__)
+
+wind_collection = db["wind_directions"]
+
+
+def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    R = 6371000.0
+    dlat = radians(lat2 - lat1)
+    dlon = radians(lon2 - lon1)
+    a = sin(dlat / 2) ** 2 + cos(radians(lat1)) * cos(radians(lat2)) * sin(dlon / 2) ** 2
+    c = 2 * asin(sqrt(a))
+    return R * c
+
+
+def sample_route_points(points: List[Coordinate]) -> List[Coordinate]:
+    sampled: List[Coordinate] = []
+    if not points or len(points) < 2:
+        return sampled
+    distance_so_far = 0.0
+    next_sample_distance = 1000.0
+    for i in range(len(points) - 1):
+        start = points[i]
+        end = points[i + 1]
+        segment_distance = haversine_distance(start.lat, start.lon, end.lat, end.lon)
+        while distance_so_far + segment_distance >= next_sample_distance:
+            distance_into_segment = next_sample_distance - distance_so_far
+            ratio = distance_into_segment / segment_distance
+            sample_lat = start.lat + ratio * (end.lat - start.lat)
+            sample_lon = start.lon + ratio * (end.lon - start.lon)
+            sampled.append(Coordinate(lat=sample_lat, lon=sample_lon))
+            next_sample_distance += 1000.0
+        distance_so_far += segment_distance
+    return sampled
+
+
+async def get_wind_direction(lat: float, lon: float) -> Optional[float]:
+    api_key = os.getenv("OPENWEATHER_API_KEY")
+    if not api_key:
+        logger.warning("OPENWEATHER_API_KEY environment variable not set")
+        return None
+    url = "https://api.openweathermap.org/data/2.5/weather"
+    params = {"lat": lat, "lon": lon, "appid": api_key}
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            resp = await client.get(url, params=params)
+        if resp.status_code != 200:
+            logger.warning(
+                "Wind API request failed for (%s,%s) with status %s",
+                lat,
+                lon,
+                resp.status_code,
+            )
+            return None
+        data = resp.json()
+        return data.get("wind", {}).get("deg")
+    except Exception as e:
+        logger.warning("Error fetching wind data for (%s,%s): %s", lat, lon, e)
+        return None
+
+
+async def compute_wind_directions(req: RouteRequest) -> List[WindResult]:
+    sample_points = sample_route_points(req.points)
+    if req.points:
+        last = req.points[-1]
+        if sample_points:
+            if (
+                haversine_distance(
+                    sample_points[-1].lat, sample_points[-1].lon, last.lat, last.lon
+                )
+                > 500
+            ):
+                sample_points.append(last)
+        else:
+            sample_points.append(last)
+
+    results: List[WindResult] = []
+    for coord in sample_points:
+        wind_deg = await get_wind_direction(coord.lat, coord.lon)
+        if wind_deg is not None:
+            results.append(WindResult(lat=coord.lat, lon=coord.lon, wind_deg=wind_deg))
+
+    record = {
+        "route_points": [
+            {"lat": p.lat, "lon": p.lon} for p in req.points
+        ],
+        "sampled_winds": [r.dict() for r in results],
+        "timestamp": datetime.utcnow(),
+    }
+    try:
+        await wind_collection.insert_one(record)
+    except Exception as e:
+        logger.warning("Failed to store wind data: %s", e)
+
+    return results

--- a/ride_aware_frontend/assets/wind_map.html
+++ b/ride_aware_frontend/assets/wind_map.html
@@ -14,8 +14,6 @@
     <div id="map"></div>
     <!-- Leaflet JS -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <!-- Leaflet-Velocity (Windy plugin) JS -->
-    <script src="https://unpkg.com/leaflet-velocity/dist/leaflet-velocity.min.js"></script>
     <script>
       // Initialize the map
       var map = L.map('map').setView([0, 0], 2);
@@ -30,23 +28,6 @@
         var bounds = L.latLngBounds(routeCoords);
         map.fitBounds(bounds, { padding: [20, 20] });
         L.polyline(routeCoords, { color: 'blue', weight: 4 }).addTo(map);
-      }
-
-      // Placeholder for wind data injected from Flutter
-      var windData = WIND_DATA_PLACEHOLDER;
-      var velocityLayer = L.velocityLayer({
-        displayValues: false,
-        displayOptions: {
-          velocityType: 'Wind',
-          position: 'bottomleft',
-          emptyString: 'No wind data'
-        },
-        data: windData,
-        maxVelocity: 20,
-        velocityScale: 0.005,
-      });
-      if (windData) {
-        velocityLayer.addTo(map);
       }
     </script>
   </body>

--- a/ride_aware_frontend/lib/screens/wind_map_screen.dart
+++ b/ride_aware_frontend/lib/screens/wind_map_screen.dart
@@ -1,14 +1,16 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
-import 'package:webview_flutter/webview_flutter.dart';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:http/http.dart' as http;
+import 'package:webview_flutter/webview_flutter.dart';
+
 import '../models/geo_point.dart';
 
 class WindMapScreen extends StatefulWidget {
   final List<GeoPoint> routePoints;
-  final Map<String, dynamic>? windData;
 
-  const WindMapScreen({super.key, required this.routePoints, this.windData});
+  const WindMapScreen({super.key, required this.routePoints});
 
   @override
   State<WindMapScreen> createState() => _WindMapScreenState();
@@ -16,6 +18,37 @@ class WindMapScreen extends StatefulWidget {
 
 class _WindMapScreenState extends State<WindMapScreen> {
   late WebViewController _webViewController;
+
+  Future<void> _fetchAndDisplayWindData() async {
+    List<Map<String, double>> coords = widget.routePoints
+        .map((p) => {'lat': p.latitude, 'lon': p.longitude})
+        .toList();
+    try {
+      final uri = Uri.parse('http://127.0.0.1:8000/wind-directions');
+      final response = await http.post(uri,
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode({'points': coords}));
+      if (response.statusCode == 200) {
+        List<dynamic> windDataList = jsonDecode(response.body);
+        for (var item in windDataList) {
+          double lat = item['lat'];
+          double lon = item['lon'];
+          double windDeg = item['wind_deg'];
+          _addWindArrow(lat, lon, windDeg);
+        }
+      } else {
+        debugPrint('Failed to fetch wind data: ${response.statusCode}');
+      }
+    } catch (e) {
+      debugPrint('Error during wind data fetch: $e');
+    }
+  }
+
+  void _addWindArrow(double lat, double lon, double windDeg) {
+    String jsCommand =
+        "L.marker([$lat, $lon], {icon: L.divIcon({className: 'wind-arrow', html: \"<div style='transform: rotate(${windDeg}deg); color: red; font-size: 20px;'>&#8593;</div>\", iconSize: [20,20], iconAnchor: [10,10]})}).addTo(map);";
+    _webViewController.runJavascript(jsCommand);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,11 +63,10 @@ class _WindMapScreenState extends State<WindMapScreen> {
               .map((p) => [p.latitude, p.longitude])
               .toList();
           html = html.replaceFirst('ROUTE_COORDS_PLACEHOLDER', jsonEncode(coords));
-          String windDataJs = widget.windData != null
-              ? jsonEncode(widget.windData)
-              : 'null';
-          html = html.replaceFirst('WIND_DATA_PLACEHOLDER', windDataJs);
           await _webViewController.loadHtmlString(html);
+        },
+        onPageFinished: (url) {
+          _fetchAndDisplayWindData();
         },
       ),
     );

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -474,13 +474,11 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
                 onTap: () {
                   if (result != null) {
                     final routePoints = result!.route.routePoints;
-                    Map<String, dynamic>? windData;
                     Navigator.push(
                       context,
                       MaterialPageRoute(
                         builder: (context) => WindMapScreen(
                           routePoints: routePoints,
-                          windData: windData,
                         ),
                       ),
                     );


### PR DESCRIPTION
## Summary
- expose `/wind-directions` endpoint that samples routes and fetches wind direction from OpenWeather, storing results in MongoDB
- display sampled wind direction arrows on Flutter map by calling backend and injecting markers

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce411cc4832890c6daa3da4eeb75