### PR TITLE
Fix pending feedback flow after wind features

### DIFF
--- a/ride_aware_frontend/lib/screens/history_screen.dart
+++ b/ride_aware_frontend/lib/screens/history_screen.dart
@@ -74,7 +74,10 @@ class _HistoryScreenState extends State<HistoryScreen> {
                           leading: _statusIcon(e.status),
                           title: Text(
                               '${_formatTime(e.startTime)}–${_formatTime(e.endTime)}'),
-                          subtitle: Text(e.feedback ?? ''),
+                          subtitle: Text(
+                            e.feedback ??
+                                'Next time you should give feedback to improve your experience.',
+                          ),
                         ),
                       );
                     },

--- a/ride_aware_frontend/lib/screens/preferences_screen.dart
+++ b/ride_aware_frontend/lib/screens/preferences_screen.dart
@@ -449,10 +449,18 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         return;
       }
 
-      await _apiService.submitThresholds(preferences);
+      final feedbackGiven =
+          await _preferencesService.isEndFeedbackGivenToday();
+      final String? newThresholdId =
+          await _apiService.submitThresholds(preferences);
       await _preferencesService.savePreferencesWithDeviceId(
         preferences,
       ); // This still uses the deviceIdService internally
+      if (newThresholdId != null && !feedbackGiven) {
+        await _preferencesService.setPendingFeedback(DateTime.now());
+      } else {
+        await _preferencesService.setPendingFeedback(null);
+      }
 
       final startLocation = GeoPoint(
         latitude: _startMarkerPoint!.latitude,

--- a/ride_aware_frontend/lib/services/preferences_service.dart
+++ b/ride_aware_frontend/lib/services/preferences_service.dart
@@ -10,6 +10,7 @@ class PreferencesService {
   static const String _prefsVersionKey = 'prefsVersion';
   static const String _lastEndFeedbackKey = 'lastEndFeedback';
   static const String _currentThresholdIdKey = 'currentThresholdId';
+  static const String _pendingFeedbackKey = 'pendingFeedback';
 
   final DeviceIdService _deviceIdService = DeviceIdService();
 
@@ -122,5 +123,25 @@ class PreferencesService {
   Future<String?> getCurrentThresholdId() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString(_currentThresholdIdKey);
+  }
+
+  Future<void> setPendingFeedback(DateTime? timestamp) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (timestamp == null) {
+      await prefs.remove(_pendingFeedbackKey);
+    } else {
+      await prefs.setString(
+          _pendingFeedbackKey, timestamp.toIso8601String());
+    }
+  }
+
+  Future<DateTime?> getPendingFeedbackSince() async {
+    final prefs = await SharedPreferences.getInstance();
+    final ts = prefs.getString(_pendingFeedbackKey);
+    return ts != null ? DateTime.tryParse(ts) : null;
+  }
+
+  Future<bool> hasPendingFeedback() async {
+    return (await getPendingFeedbackSince()) != null;
   }
 }


### PR DESCRIPTION
## Summary
- track pending feedback in preferences and set when creating new routes
- refine dashboard feedback card timing and history saving
- show reminder when ride feedback is missing

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a8351d248328be451ba69370a263