### PR TITLE
Fix feedback handling and preserve ride history

### DIFF
--- a/ride_aware_backend/controllers/ride_history_controller.py
+++ b/ride_aware_backend/controllers/ride_history_controller.py
@@ -24,7 +24,7 @@ async def create_history_entry(
         "feedback": None,
     }
     await ride_history_collection.update_one(
-        {"threshold_id": threshold_id}, {"$set": doc}, upsert=True
+        {"threshold_id": threshold_id}, {"$setOnInsert": doc}, upsert=True
     )
 
 

--- a/ride_aware_backend/tests/controllers/test_ride_history_controller.py
+++ b/ride_aware_backend/tests/controllers/test_ride_history_controller.py
@@ -10,7 +10,7 @@ class DummyCollection:
         self.args = (filter_doc, update_doc, upsert)
 
 
-def test_create_history_entry_resets_document(monkeypatch):
+def test_create_history_entry_sets_defaults_on_insert(monkeypatch):
     dummy = DummyCollection()
     monkeypatch.setattr(ride_history_controller, "ride_history_collection", dummy)
 
@@ -23,5 +23,5 @@ def test_create_history_entry_resets_document(monkeypatch):
     assert dummy.args is not None
     filter_doc, update_doc, upsert = dummy.args
     assert filter_doc == {"threshold_id": "th1"}
-    assert update_doc["$set"]["feedback"] is None
+    assert update_doc["$setOnInsert"]["feedback"] is None
     assert upsert is True

--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -175,13 +175,14 @@ class _DashboardScreenState extends State<DashboardScreen>
         centerTitle: true,
         actions: [
           IconButton(
-            onPressed: () {
-              Navigator.push(
+            onPressed: () async {
+              await Navigator.push(
                 context,
                 MaterialPageRoute(
                   builder: (context) => const PreferencesScreen(),
                 ),
               );
+              await _loadPrefs();
             },
             icon: const Icon(Icons.settings),
             tooltip: 'Settings',
@@ -260,6 +261,7 @@ class _DashboardScreenState extends State<DashboardScreen>
             UpcomingCommuteAlert(
               key: _alertKey,
               feedbackSummary: _feedbackSummary,
+              onThresholdUpdated: _loadPrefs,
             ),
 
             Card(

--- a/ride_aware_frontend/lib/screens/preferences_screen.dart
+++ b/ride_aware_frontend/lib/screens/preferences_screen.dart
@@ -458,6 +458,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       await _preferencesService.savePreferencesWithDeviceId(
         preferences,
       ); // This still uses the deviceIdService internally
+      await _preferencesService.clearEndFeedbackGiven();
       if (newThresholdId != null && !feedbackGiven && oldThresholdId != null) {
         await _preferencesService.setPendingFeedback(DateTime.now());
         await _preferencesService

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -35,10 +35,12 @@ class _StatusInfo {
 
 class UpcomingCommuteAlert extends StatefulWidget {
   final String feedbackSummary;
+  final Future<void> Function()? onThresholdUpdated;
 
   const UpcomingCommuteAlert({
     super.key,
     this.feedbackSummary = 'You did a great job!',
+    this.onThresholdUpdated,
   });
 
   @override
@@ -918,6 +920,7 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
       final String? newThresholdId =
           await _apiService.submitThresholds(updatedPrefs);
       await _preferencesService.savePreferencesWithDeviceId(updatedPrefs);
+      await _preferencesService.clearEndFeedbackGiven();
       if (newThresholdId != null && !feedbackGiven && oldThresholdId != null) {
         await _preferencesService.setPendingFeedback(DateTime.now());
         await _preferencesService
@@ -926,6 +929,8 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
         await _preferencesService.setPendingFeedback(null);
         await _preferencesService.setPendingFeedbackThresholdId(null);
       }
+
+      await widget.onThresholdUpdated?.call();
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- avoid overwriting existing ride history feedback when thresholds are updated
- reset stored feedback status when new thresholds are submitted so the feedback card is interactive again
- reload preferences after settings or threshold changes

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893b6ea389083239811a16cf4413a74