### PR TITLE
Add next hours forecast feature

### DIFF
--- a/ride_aware_backend/controllers/forecast_controller.py
+++ b/ride_aware_backend/controllers/forecast_controller.py
@@ -1,8 +1,12 @@
 import logging
 from datetime import datetime
 from typing import List, Dict
-from services.weather_service import get_hourly_forecast
+from services.weather_service import (
+    get_hourly_forecast,
+    get_next_hours_forecast,
+)
 from services.route_weather_service import evaluate_route_weather
+from services.forecast_cache_service import save_hourly_forecasts
 from models.thresholds import WeatherLimits
 
 logger = logging.getLogger(__name__)
@@ -11,6 +15,19 @@ async def get_forecast(lat: float, lon: float, time: datetime) -> dict:
     """Controller layer for single forecast snapshot."""
     logger.info("Getting forecast for lat=%s lon=%s at %s", lat, lon, time)
     return get_hourly_forecast(lat, lon, time)
+
+
+async def get_next_hours(lat: float, lon: float, hours: int) -> list:
+    """Controller layer for upcoming hours forecast and persistence."""
+    logger.info(
+        "Controller retrieving next %s hours forecast for lat=%s lon=%s",
+        hours,
+        lat,
+        lon,
+    )
+    data = get_next_hours_forecast(lat, lon, hours)
+    await save_hourly_forecasts(lat, lon, data)
+    return data
 
 
 async def evaluate_route(

--- a/ride_aware_backend/services/db.py
+++ b/ride_aware_backend/services/db.py
@@ -13,6 +13,7 @@ routes_collection = db["routes"]
 fcm_tokens_collection = db["fcm_tokens"]
 feedback_collection = db["feedback"]
 ride_history_collection = db["ride_history"]
+forecasts_collection = db["forecasts"]
 
 
 async def init_db() -> None:

--- a/ride_aware_backend/services/forecast_cache_service.py
+++ b/ride_aware_backend/services/forecast_cache_service.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Dict
+
+from .db import forecasts_collection
+
+async def save_hourly_forecasts(lat: float, lon: float, forecasts: List[Dict]) -> None:
+    """Store forecasts in the database with metadata."""
+    doc = {
+        "lat": lat,
+        "lon": lon,
+        "created_at": datetime.utcnow(),
+        "forecasts": forecasts,
+    }
+    await forecasts_collection.insert_one(doc)

--- a/ride_aware_backend/tests/routes/test_forecast_route.py
+++ b/ride_aware_backend/tests/routes/test_forecast_route.py
@@ -75,3 +75,21 @@ def test_route_forecast(monkeypatch):
     resp = client.post("/api/forecast/route", json=body)
     assert resp.status_code == 200
     assert resp.json()["summary"]["max_wind_speed"] == 5
+
+
+def test_forecast_next(monkeypatch):
+    async def fake_next_hours(lat: float, lon: float, hours: int):
+        return [{"temp": 20}]
+
+    monkeypatch.setattr(forecast, "get_next_hours", fake_next_hours)
+
+    app = FastAPI()
+    app.include_router(forecast.router)
+    client = TestClient(app)
+
+    resp = client.get(
+        "/api/forecast/next",
+        params={"lat": 1.0, "lon": 2.0, "hours": 6},
+    )
+    assert resp.status_code == 200
+    assert resp.json()[0]["temp"] == 20

--- a/ride_aware_frontend/lib/services/forecast_service.dart
+++ b/ride_aware_frontend/lib/services/forecast_service.dart
@@ -60,6 +60,36 @@ class ForecastService {
     }
   }
 
+  Future<List<Map<String, dynamic>>> getNextHoursForecast(
+    double lat,
+    double lon,
+    int hours,
+  ) async {
+    final uri = Uri.parse('${ApiService.baseUrl}/api/forecast/next').replace(
+      queryParameters: {
+        'lat': lat.toString(),
+        'lon': lon.toString(),
+        'hours': hours.toString(),
+      },
+    );
+    final response = await _client.get(uri, headers: await _getHeaders());
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as List;
+      return data.map<Map<String, dynamic>>((e) {
+        final m = Map<String, dynamic>.from(e as Map);
+        const keys = {'wind_speed', 'wind_deg', 'rain', 'humidity', 'temp'};
+        for (final k in keys) {
+          if (m.containsKey(k)) {
+            m[k] = parseDouble(m[k]);
+          }
+        }
+        return m;
+      }).toList();
+    } else {
+      throw Exception('Failed to load forecast: ${response.statusCode}');
+    }
+  }
+
   /// Evaluate weather along a route of [points] at the specified [time].
   Future<Map<String, dynamic>> evaluateRoute(
     List<GeoPoint> points,

--- a/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
+++ b/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
@@ -35,6 +35,7 @@ class UpcomingCommuteViewModel extends ChangeNotifier {
   String? error;
   bool needsCommuteTime = false;
   CommuteAlertResult? result;
+  List<Map<String, dynamic>>? hourlyForecasts;
 
   Future<void> load() async {
     isLoading = true;
@@ -59,6 +60,10 @@ class UpcomingCommuteViewModel extends ChangeNotifier {
       final sampled = _sampleRoute(route);
       final evaluation = await _forecastService.evaluateRoute(
           sampled, targetTime, prefs.weatherLimits);
+      hourlyForecasts = await _forecastService.getNextHoursForecast(
+          route.startLocation.latitude,
+          route.startLocation.longitude,
+          6);
       result = CommuteAlertResult(
         time: targetTime,
         limits: prefs.weatherLimits,

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -145,7 +145,7 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
       showPostCommuteCard = now.isAfter(todayStartTime);
     }
 
-    return Card(
+    final mainCard = Card(
       margin: const EdgeInsets.all(16),
       elevation: 8,
       shadowColor: status.color.withOpacity(0.3),
@@ -225,6 +225,13 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
         ),
       ),
     );
+
+    final cards = <Widget>[mainCard];
+    if (_vm.hourlyForecasts != null && _vm.hourlyForecasts!.isNotEmpty) {
+      cards.add(_buildHourlyForecastCard(theme));
+    }
+
+    return Column(children: cards);
   }
 
   Widget _buildStatusHeader(
@@ -1053,6 +1060,71 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildHourlyForecastCard(ThemeData theme) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        title: Text(t('Next 6 Hours Forecast')),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: _showHourlyForecastDialog,
+      ),
+    );
+  }
+
+  void _showHourlyForecastDialog() {
+    final theme = Theme.of(context);
+    final forecasts = _vm.hourlyForecasts ?? [];
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(t('Next 6 Hours')),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: forecasts.length,
+              itemBuilder: (context, index) {
+                final f = forecasts[index];
+                DateTime? time;
+                final timeStr = f['time']?.toString();
+                if (timeStr != null) {
+                  time = DateTime.tryParse(timeStr);
+                }
+                final label = time != null
+                    ? '${time.hour.toString().padLeft(2, '0')}:00'
+                    : 'Hour ${index + 1}';
+                return Card(
+                  margin: const EdgeInsets.symmetric(vertical: 4),
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(label, style: theme.textTheme.titleMedium),
+                        Text('Temp: ${f['temp'] ?? '--'}°C'),
+                        Text(
+                            'Wind: ${f['wind_speed'] ?? '--'} m/s ${f['wind_deg'] ?? '--'}°'),
+                        Text('Rain: ${f['rain'] ?? 0}'),
+                        Text('Humidity: ${f['humidity'] ?? '--'}%'),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
     );
   }
 

--- a/ride_aware_frontend/test/forecast_service_test.dart
+++ b/ride_aware_frontend/test/forecast_service_test.dart
@@ -73,4 +73,31 @@ void main() {
     );
     expect(res['summary']['max_wind_speed'], 5);
   });
+
+  test('getNextHoursForecast returns parsed list', () async {
+    final mockClient = MockClient((request) async {
+      expect(request.url.path, contains('/api/forecast/next'));
+      return http.Response(
+          jsonEncode([
+            {
+              'time': '2024-01-01T01:00:00Z',
+              'wind_speed': '5',
+              'wind_deg': '180',
+              'rain': '0.1',
+              'humidity': '70',
+              'temp': '15'
+            }
+          ]),
+          200);
+    });
+
+    final service = ForecastService(
+      client: mockClient,
+      deviceIdService: _FakeDeviceIdService(),
+    );
+
+    final res = await service.getNextHoursForecast(0, 0, 1);
+    expect(res, isA<List>());
+    expect(res.first['temp'], 15.0);
+  });
 }


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch and store upcoming hourly forecasts
- support frontend service and view model for next 6 hour forecast
- show clickable card with next 6-hour weather details in upcoming commute

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*
- `sudo apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893beef09f48323925d1b81379e9229