### PR TITLE
feat: standardize dashboard cards

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -5,6 +5,7 @@ import 'package:active_commuter_support/screens/preferences_screen.dart';
 import 'package:active_commuter_support/services/notification_service.dart';
 import 'package:active_commuter_support/services/preferences_service.dart';
 import 'package:active_commuter_support/widgets/upcoming_commute_alert.dart';
+import 'package:active_commuter_support/widgets/standard_card.dart';
 import 'package:active_commuter_support/screens/post_ride_feedback_screen.dart';
 import 'package:active_commuter_support/screens/history_screen.dart';
 import 'package:active_commuter_support/services/api_service.dart';
@@ -222,9 +223,9 @@ class _DashboardScreenState extends State<DashboardScreen>
 
             // Commute Feedback Card
             if (showFeedback)
-              Card(
-                margin: const EdgeInsets.all(16),
+              StandardCard(
                 child: ListTile(
+                  contentPadding: EdgeInsets.zero,
                   leading: Icon(
                     Icons.feedback,
                     color: _endFeedbackGiven
@@ -268,9 +269,9 @@ class _DashboardScreenState extends State<DashboardScreen>
               onThresholdUpdated: _loadPrefs,
             ),
 
-            Card(
-              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            StandardCard(
               child: ListTile(
+                contentPadding: EdgeInsets.zero,
                 leading: Icon(Icons.history,
                     color: Theme.of(context).colorScheme.primary),
                 title: const Text('Ride History'),
@@ -290,10 +291,9 @@ class _DashboardScreenState extends State<DashboardScreen>
               future: _notificationService.areNotificationsEnabled(),
               builder: (context, snapshot) {
                 final enabled = snapshot.data ?? false;
-                return Card(
-                  margin:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                return StandardCard(
                   child: SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
                     title: const Text('Enable weather alerts'),
                     secondary: Icon(Icons.notifications,
                         color: Theme.of(context).colorScheme.primary),
@@ -335,9 +335,9 @@ class _DashboardScreenState extends State<DashboardScreen>
             // ),
 
             // App Refresh Card
-            Card(
-              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            StandardCard(
               child: ListTile(
+                contentPadding: EdgeInsets.zero,
                 leading: Icon(Icons.refresh,
                     color: Theme.of(context).colorScheme.primary),
                 title: const Text('Refresh App'),

--- a/ride_aware_frontend/lib/widgets/standard_card.dart
+++ b/ride_aware_frontend/lib/widgets/standard_card.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class StandardCard extends StatelessWidget {
+  final Widget child;
+  const StandardCard({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `StandardCard` widget with consistent margin, rounding, and padding
- refactor dashboard to use `StandardCard` for feedback, history, notification, and refresh sections

## Testing
- `dart format lib/widgets/standard_card.dart lib/screens/dashboard_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893db28d7208328a91156ac82134238