### PR TITLE
feat: apply unified dark theme

### DIFF
--- a/ride_aware_frontend/lib/main.dart
+++ b/ride_aware_frontend/lib/main.dart
@@ -4,11 +4,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 
 import 'app_initializer.dart';
 import 'services/notification_service.dart';
-
-// Global color definitions for consistent theming
-const Color _primaryBlue = Color(0xFF2196F3);
-const Color _successGreen = Color(0xFF4CAF50);
-const Color _darkBackground = Color(0xFF121212);
+import 'theme/app_theme.dart';
 
 // Top-level function to handle background messages
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
@@ -39,25 +35,8 @@ class ActiveCommuterApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Active Commuter Support System',
-      theme: ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: _primaryBlue,
-        ).copyWith(secondary: _successGreen),
-      ),
-      darkTheme: ThemeData(
-        useMaterial3: true,
-        scaffoldBackgroundColor: _darkBackground,
-        cardColor: const Color(0xFF1E1E1E),
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: _primaryBlue,
-          brightness: Brightness.dark,
-        ).copyWith(
-          secondary: _successGreen,
-          background: _darkBackground,
-          surface: const Color(0xFF1E1E1E),
-        ),
-      ),
+      theme: AppTheme.darkTheme,
+      darkTheme: AppTheme.darkTheme,
       themeMode: ThemeMode.dark,
       home: const AppInitializer(),
       debugShowCheckedModeBanner: false,

--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -6,6 +6,7 @@ import 'package:active_commuter_support/services/notification_service.dart';
 import 'package:active_commuter_support/services/preferences_service.dart';
 import 'package:active_commuter_support/widgets/upcoming_commute_alert.dart';
 import 'package:active_commuter_support/widgets/standard_card.dart';
+import 'package:active_commuter_support/widgets/standard_list_tile.dart';
 import 'package:active_commuter_support/screens/post_ride_feedback_screen.dart';
 import 'package:active_commuter_support/screens/history_screen.dart';
 import 'package:active_commuter_support/services/api_service.dart';
@@ -269,22 +270,18 @@ class _DashboardScreenState extends State<DashboardScreen>
               onThresholdUpdated: _loadPrefs,
             ),
 
-            StandardCard(
-              child: ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: Icon(Icons.history,
-                    color: Theme.of(context).colorScheme.primary),
-                title: const Text('Ride History'),
-                subtitle: const Text('View your last 30 days of rides'),
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const HistoryScreen(),
-                    ),
-                  );
-                },
-              ),
+            StandardListTile(
+              icon: Icons.history,
+              title: 'Ride History',
+              subtitle: 'View your last 30 days of rides',
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const HistoryScreen(),
+                  ),
+                );
+              },
             ),
 
             FutureBuilder<bool>(
@@ -335,22 +332,16 @@ class _DashboardScreenState extends State<DashboardScreen>
             // ),
 
             // App Refresh Card
-            StandardCard(
-              child: ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: Icon(Icons.refresh,
-                    color: Theme.of(context).colorScheme.primary),
-                title: const Text('Refresh App'),
-                subtitle:
-                    const Text('Restart the app and reload all data'),
-                onTap: () {
-                  Navigator.of(context).pushAndRemoveUntil(
-                    MaterialPageRoute(
-                        builder: (_) => const AppInitializer()),
-                    (route) => false,
-                  );
-                },
-              ),
+            StandardListTile(
+              icon: Icons.refresh,
+              title: 'Refresh App',
+              subtitle: 'Restart the app and reload all data',
+              onTap: () {
+                Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (_) => const AppInitializer()),
+                  (route) => false,
+                );
+              },
             ),
             const SizedBox(height: 16),
           ],

--- a/ride_aware_frontend/lib/screens/preferences_screen.dart
+++ b/ride_aware_frontend/lib/screens/preferences_screen.dart
@@ -628,10 +628,11 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
             const SizedBox(height: 16),
             _buildNumberField(
               controller: _windSpeedController,
-              label: 'Max wind speed (km/h)',
-              helperText: '0 – 200 km/h',
+              label: 'Max wind speed',
+              helperText: '0 – 200',
               min: 0,
               max: 200,
+              unit: 'km/h',
             ),
             const SizedBox(height: 16),
             Column(
@@ -682,19 +683,21 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
             const SizedBox(height: 16),
             _buildNumberField(
               controller: _rainIntensityController,
-              label: 'Max rain intensity (mm/h)',
-              helperText: '0 – 50 mm/h',
+              label: 'Max rain intensity',
+              helperText: '0 – 50',
               min: 0,
               max: 50,
               allowDecimals: true,
+              unit: 'mm/h',
             ),
             const SizedBox(height: 16),
             _buildNumberField(
               controller: _humidityController,
-              label: 'Max humidity (%)',
-              helperText: '0 – 100%',
+              label: 'Max humidity',
+              helperText: '0 – 100',
               min: 0,
               max: 100,
+              unit: '%',
             ),
             const SizedBox(height: 16),
             Row(
@@ -702,20 +705,22 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                 Expanded(
                   child: _buildNumberField(
                     controller: _minTemperatureController,
-                    label: 'Min temperature (°C)',
-                    helperText: '-50 – 60°C',
+                    label: 'Min temperature',
+                    helperText: '-50 – 60',
                     min: -50,
                     max: 60,
+                    unit: '°C',
                   ),
                 ),
                 const SizedBox(width: 16),
                 Expanded(
                   child: _buildNumberField(
                     controller: _maxTemperatureController,
-                    label: 'Max temperature (°C)',
-                    helperText: '-50 – 60°C',
+                    label: 'Max temperature',
+                    helperText: '-50 – 60',
                     min: -50,
                     max: 60,
+                    unit: '°C',
                   ),
                 ),
               ],
@@ -740,18 +745,20 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
             const SizedBox(height: 16),
             _buildNumberField(
               controller: _visibilityController,
-              label: 'Min visibility (m)',
-              helperText: '0 – 10000 m',
+              label: 'Min visibility',
+              helperText: '0 – 10000',
               min: 0,
               max: 10000,
+              unit: 'm',
             ),
             const SizedBox(height: 16),
             _buildNumberField(
               controller: _pollutionController,
-              label: 'Max pollution (AQI)',
-              helperText: '0 – 500 AQI',
+              label: 'Max pollution',
+              helperText: '0 – 500',
               min: 0,
               max: 500,
+              unit: 'AQI',
             ),
             const SizedBox(height: 16),
             _buildNumberField(
@@ -1020,6 +1027,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
     required double min,
     required double max,
     bool allowDecimals = false,
+    String? unit,
   }) {
     return TextFormField(
       controller: controller,
@@ -1036,6 +1044,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       decoration: InputDecoration(
         labelText: label,
         helperText: helperText,
+        suffixText: unit,
         border: const OutlineInputBorder(),
       ),
       validator: (value) {
@@ -1074,16 +1083,16 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   Widget _buildSubmitButton() {
     return SizedBox(
       width: double.infinity,
-      child: FilledButton(
+      child: FilledButton.icon(
         onPressed:
             (_isSubmitting ||
-                _isGettingLocation ||
-                _isFetchingRoute ||
-                _routePolylinePoints.isEmpty)
-            ? null
-            : _submitPreferencesAndRoute,
+                    _isGettingLocation ||
+                    _isFetchingRoute ||
+                    _routePolylinePoints.isEmpty)
+                ? null
+                : _submitPreferencesAndRoute,
         style: FilledButton.styleFrom(minimumSize: const Size(0, 48)),
-        child: _isSubmitting
+        icon: _isSubmitting
             ? const SizedBox(
                 width: 20,
                 height: 20,
@@ -1092,7 +1101,8 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                   color: Colors.white,
                 ),
               )
-            : const Text('Save preferences and Route'),
+            : const Icon(Icons.save),
+        label: Text(_isSubmitting ? 'Saving...' : 'Save'),
       ),
     );
   }

--- a/ride_aware_frontend/lib/theme/app_theme.dart
+++ b/ride_aware_frontend/lib/theme/app_theme.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+/// Centralized application theme definitions.
+class AppTheme {
+  // Core color palette
+  static const Color primary = Color(0xFF6750A4);
+  static const Color onPrimary = Colors.white;
+  static const Color secondary = Color(0xFF625B71);
+  static const Color surface = Color(0xFF1C1B1F);
+  static const Color onSurface = Color(0xFFE6E1E5);
+
+  /// Material 3 dark theme used throughout the app.
+  static ThemeData get darkTheme {
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: const ColorScheme.dark(
+        primary: primary,
+        onPrimary: onPrimary,
+        secondary: secondary,
+        surface: surface,
+        background: surface,
+        onSurface: onSurface,
+      ),
+      scaffoldBackgroundColor: surface,
+      cardTheme: const CardTheme(
+        margin: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(12)),
+        ),
+      ),
+      textTheme: const TextTheme(
+        titleLarge: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
+        bodyMedium: TextStyle(fontSize: 16),
+      ),
+    );
+  }
+}
+

--- a/ride_aware_frontend/lib/widgets/standard_list_tile.dart
+++ b/ride_aware_frontend/lib/widgets/standard_list_tile.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import 'standard_card.dart';
+
+/// A ListTile wrapped in [StandardCard] with consistent styling.
+class StandardListTile extends StatelessWidget {
+  const StandardListTile({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.subtitle,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return StandardCard(
+      child: ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: Icon(icon, color: Theme.of(context).colorScheme.primary),
+        title: Text(title),
+        subtitle: subtitle != null ? Text(subtitle!) : null,
+        trailing: onTap != null ? const Icon(Icons.chevron_right) : null,
+        onTap: onTap,
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement centralized AppTheme using Material 3 dark colors
- standardize navigation tiles and add them to dashboard
- clarify preference inputs with unit suffixes and icon Save button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893dfc50cb48328be723ffb2bcb44a7