### PR TITLE
Refactor ride history and feedback tracking

### DIFF
--- a/ride_aware_frontend/lib/models/ride_slot.dart
+++ b/ride_aware_frontend/lib/models/ride_slot.dart
@@ -1,0 +1,35 @@
+class RideSlot {
+  final DateTime startUtc;
+  final DateTime endUtc;
+  final String rideId;
+  RideSlot({required this.startUtc, required this.endUtc, required this.rideId});
+}
+
+class FeedbackWindow {
+  final DateTime showAt;
+  final DateTime hideAt;
+  FeedbackWindow({required this.showAt, required this.hideAt});
+}
+
+FeedbackWindow windowFor(RideSlot current, RideSlot? next) {
+  final showAt = current.endUtc.toLocal().add(const Duration(hours: 1));
+  final hideAt = (next == null
+          ? DateTime.fromMillisecondsSinceEpoch(8640000000000000, isUtc: true)
+          : next.startUtc)
+      .toLocal()
+      .subtract(const Duration(minutes: 1));
+  return FeedbackWindow(showAt: showAt, hideAt: hideAt);
+}
+
+bool shouldShowFeedback({
+  required RideSlot current,
+  required RideSlot? next,
+  required bool feedbackAlreadySubmitted,
+  DateTime? nowLocal,
+}) {
+  if (feedbackAlreadySubmitted) return false;
+  final now = nowLocal ?? DateTime.now();
+  final win = windowFor(current, next);
+  if (now.isAfter(win.hideAt)) return false;
+  return !now.isBefore(win.showAt);
+}

--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -145,14 +145,24 @@ class _DashboardScreenState extends State<DashboardScreen>
     final thresholdId = await _prefsService.getCurrentThresholdId();
     if (thresholdId == null) return;
 
+    final start = DateTime(now.year, now.month, now.day,
+            _prefs!.commuteWindows.startLocal.hour,
+            _prefs!.commuteWindows.startLocal.minute)
+        .toUtc();
+    final end = DateTime(now.year, now.month, now.day,
+            _prefs!.commuteWindows.endLocal.hour,
+            _prefs!.commuteWindows.endLocal.minute)
+        .toUtc();
+
     final entry = RideHistoryEntry(
-      thresholdId: thresholdId,
-      date: DateTime.now().toUtc(),
-      startTime: _prefs!.commuteWindows.startLocal,
-      endTime: _prefs!.commuteWindows.endLocal,
+      rideId: thresholdId,
+      startUtc: start,
+      endUtc: end,
       status: result.status,
       summary: result.summary,
+      threshold: null,
       feedback: null,
+      weather: const [],
     );
     try {
       await _apiService.saveRideHistoryEntry(entry);

--- a/ride_aware_frontend/lib/services/preferences_service.dart
+++ b/ride_aware_frontend/lib/services/preferences_service.dart
@@ -13,6 +13,7 @@ class PreferencesService {
   static const String _pendingFeedbackKey = 'pendingFeedback';
   static const String _pendingFeedbackThresholdIdKey =
       'pendingFeedbackThresholdId';
+  static const String _feedbackSubmittedPrefix = 'feedbackSubmitted_';
 
   final DeviceIdService _deviceIdService = DeviceIdService();
 
@@ -159,5 +160,20 @@ class PreferencesService {
 
   Future<bool> hasPendingFeedback() async {
     return (await getPendingFeedbackSince()) != null;
+  }
+
+  Future<void> setFeedbackSubmitted(String rideId, bool submitted) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_feedbackSubmittedPrefix$rideId';
+    if (submitted) {
+      await prefs.setBool(key, true);
+    } else {
+      await prefs.remove(key);
+    }
+  }
+
+  Future<bool> getFeedbackSubmitted(String rideId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('$_feedbackSubmittedPrefix$rideId') ?? false;
   }
 }


### PR DESCRIPTION
## Summary
- expand `RideHistoryEntry` to carry ride IDs, UTC times, threshold data and weather history
- show threshold and weather details in ride history screen
- track per-ride feedback submission in preferences and add helpers for feedback timing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c2bcfe5a48328bd73c05fab7823b9