### PR TITLE
Use ride lifecycle callbacks for feedback and history

### DIFF
--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -36,11 +36,23 @@ class _StatusInfo {
 class UpcomingCommuteAlert extends StatefulWidget {
   final String feedbackSummary;
   final Future<void> Function()? onThresholdUpdated;
+  final Future<void> Function(String rideId, DateTime startUtc,
+      Map<String, dynamic> threshold)? onRideStarted;
+  final Future<void> Function(
+      String rideId,
+      DateTime startUtc,
+      DateTime endUtc,
+      String status,
+      Map<String, dynamic> summary,
+      Map<String, dynamic> threshold,
+      List<Map<String, dynamic>> weatherHistory)? onRideEnded;
 
   const UpcomingCommuteAlert({
     super.key,
     this.feedbackSummary = 'You did a great job!',
     this.onThresholdUpdated,
+    this.onRideStarted,
+    this.onRideEnded,
   });
 
   @override


### PR DESCRIPTION
## Summary
- Track ride lifecycle using new `RideSlot` model and periodic refresh
- Save ride history and feedback state when `onRideEnded` fires
- Expose ride start/end callbacks from `UpcomingCommuteAlert`

## Testing
- `dart format lib/screens/dashboard_screen.dart lib/widgets/upcoming_commute_alert.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3471495883289875c30e26f367d7