### PR TITLE
feat: enhance thresholds with commute parameters

### DIFF
--- a/ride_aware_backend/controllers/ride_history_controller.py
+++ b/ride_aware_backend/controllers/ride_history_controller.py
@@ -14,7 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 async def create_history_entry(
-    device_id: str, threshold_id: str, date: str, start_time: str, end_time: str
+    device_id: str,
+    threshold_id: str,
+    date: str,
+    start_time: str,
+    end_time: str,
+    threshold_snapshot: dict,
 ) -> None:
     """Create an empty history record linked to a threshold."""
     doc = {
@@ -25,12 +30,15 @@ async def create_history_entry(
         "end_time": end_time,
         "status": "pending",
         "summary": {},
+        "threshold": threshold_snapshot,
         "feedback": None,
     }
     await ride_history_collection.update_one(
         {"threshold_id": threshold_id}, {"$setOnInsert": doc}, upsert=True
     )
-    await schedule_weather_collection(device_id, threshold_id, start_time, end_time)
+    await schedule_weather_collection(
+        device_id, threshold_id, date, start_time, end_time
+    )
 
 
 async def save_ride(entry: RideHistoryEntry) -> dict:

--- a/ride_aware_backend/controllers/threshold_controller.py
+++ b/ride_aware_backend/controllers/threshold_controller.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from fastapi import HTTPException
 from models.thresholds import Thresholds
 from services.db import thresholds_collection
@@ -45,7 +46,7 @@ async def upsert_threshold(threshold: Thresholds) -> dict:
     threshold_id_str = str(threshold_id)
     await create_feedback_entry(device_id, threshold_id_str)
     await create_history_entry(
-        device_id, threshold_id_str, date, start_time, end_time
+        device_id, threshold_id_str, date, start_time, end_time, data
     )
     await schedule_pre_route_alert(threshold)
 
@@ -103,4 +104,23 @@ async def get_thresholds(device_id: str, date: str, start_time: str, end_time: s
     # Remove _id and validate through model
     doc.pop("_id", None)
     return Thresholds(**doc).model_dump(mode="json")
+
+
+async def get_current_threshold(device_id: str) -> dict:
+    today = datetime.utcnow().date().isoformat()
+    doc = await thresholds_collection.find_one({"device_id": device_id, "date": today})
+    if not doc:
+        cursor = (
+            thresholds_collection.find({"device_id": device_id})
+            .sort([("date", -1), ("start_time", -1)])
+            .limit(1)
+        )
+        docs = await cursor.to_list(1)
+        doc = docs[0] if docs else None
+    if not doc:
+        raise HTTPException(status_code=404, detail="Thresholds not found")
+    threshold_id = str(doc.pop("_id"))
+    payload = Thresholds(**doc).model_dump(mode="json")
+    payload["threshold_id"] = threshold_id
+    return payload
 

--- a/ride_aware_backend/models/ride_history.py
+++ b/ride_aware_backend/models/ride_history.py
@@ -10,5 +10,6 @@ class RideHistoryEntry(BaseModel):
     end_time: str
     status: str
     summary: Dict[str, object]
+    threshold: Dict[str, object]
     feedback: Optional[str] = None
     weather_history: Optional[List[Dict[str, object]]] = None

--- a/ride_aware_backend/models/thresholds.py
+++ b/ride_aware_backend/models/thresholds.py
@@ -32,5 +32,7 @@ class Thresholds(BaseModel):
     date: DateStr
     start_time: TimeStr
     end_time: TimeStr
+    presence_radius_m: int = Field(default=100, ge=1)
+    speed_cutoff_kmh: int = Field(default=5, ge=0)
     weather_limits: WeatherLimits
     office_location: OfficeLocation

--- a/ride_aware_backend/routes/thresholds.py
+++ b/ride_aware_backend/routes/thresholds.py
@@ -1,7 +1,11 @@
 import logging
 from fastapi import APIRouter, Request
 from models.thresholds import Thresholds
-from controllers.threshold_controller import upsert_threshold, get_thresholds
+from controllers.threshold_controller import (
+    upsert_threshold,
+    get_thresholds,
+    get_current_threshold,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -33,4 +37,10 @@ async def fetch_threshold(device_id: str, date: str, start_time: str, end_time: 
         end_time,
     )
     return await get_thresholds(device_id, date, start_time, end_time)
+
+
+@router.get("/{device_id}/current")
+async def fetch_current_threshold(device_id: str):
+    logger.info("Fetching current thresholds for device %s", device_id)
+    return await get_current_threshold(device_id)
 

--- a/ride_aware_backend/tests/controllers/test_ride_history_controller.py
+++ b/ride_aware_backend/tests/controllers/test_ride_history_controller.py
@@ -23,13 +23,22 @@ def test_create_history_entry_sets_defaults_on_insert(monkeypatch):
 
     asyncio.run(
         ride_history_controller.create_history_entry(
-            "dev1", "th1", "2024-01-01", "08:00", "09:00"
+            "dev1",
+            "th1",
+            "2024-01-01",
+            "08:00",
+            "09:00",
+            {"presence_radius_m": 100, "speed_cutoff_kmh": 5},
         )
     )
 
     assert dummy.args is not None
     filter_doc, update_doc, upsert = dummy.args
     assert filter_doc == {"threshold_id": "th1"}
-    assert update_doc["$setOnInsert"]["feedback"] is None
+    on_insert = update_doc["$setOnInsert"]
+    assert on_insert["feedback"] is None
+    assert on_insert["threshold"]["presence_radius_m"] == 100
     assert upsert is True
-    sched.assert_awaited_once_with("dev1", "th1", "08:00", "09:00")
+    sched.assert_awaited_once_with(
+        "dev1", "th1", "2024-01-01", "08:00", "09:00"
+    )

--- a/ride_aware_backend/tests/routes/test_threshold_route.py
+++ b/ride_aware_backend/tests/routes/test_threshold_route.py
@@ -48,3 +48,15 @@ def test_set_threshold_validation_error():
     }
     response = client.post("/thresholds", json=payload)
     assert response.status_code == 422
+
+
+def test_get_current_threshold(monkeypatch):
+    async def fake_get_current(device_id: str):
+        return {"device_id": device_id}
+
+    monkeypatch.setattr(
+        threshold_route, "get_current_threshold", fake_get_current
+    )
+    response = client.get("/thresholds/device123/current")
+    assert response.status_code == 200
+    assert response.json()["device_id"] == "device123"

--- a/ride_aware_frontend/lib/models/user_preferences.dart
+++ b/ride_aware_frontend/lib/models/user_preferences.dart
@@ -6,12 +6,16 @@ class UserPreferences {
   final EnvironmentalRisk environmentalRisk;
   final OfficeLocation officeLocation;
   final CommuteWindows commuteWindows;
+  final int presenceRadiusM;
+  final int speedCutoffKmh;
 
   const UserPreferences({
     required this.weatherLimits,
     required this.environmentalRisk,
     required this.officeLocation,
     required this.commuteWindows,
+    this.presenceRadiusM = 100,
+    this.speedCutoffKmh = 5,
   });
 
   // Default preferences for first-time users
@@ -21,6 +25,8 @@ class UserPreferences {
       environmentalRisk: EnvironmentalRisk.defaultValues(),
       officeLocation: OfficeLocation.empty(),
       commuteWindows: CommuteWindows.defaultValues(),
+      presenceRadiusM: 100,
+      speedCutoffKmh: 5,
     );
   }
 
@@ -36,6 +42,8 @@ class UserPreferences {
         'start': json['start_time'] ?? '07:30',
         'end': json['end_time'] ?? '17:30',
       }),
+      presenceRadiusM: json['presence_radius_m'] ?? 100,
+      speedCutoffKmh: json['speed_cutoff_kmh'] ?? 5,
     );
   }
 
@@ -47,6 +55,8 @@ class UserPreferences {
       'office_location': officeLocation.toJson(),
       'start_time': commuteWindows.start,
       'end_time': commuteWindows.end,
+      'presence_radius_m': presenceRadiusM,
+      'speed_cutoff_kmh': speedCutoffKmh,
     };
   }
 
@@ -56,12 +66,16 @@ class UserPreferences {
     EnvironmentalRisk? environmentalRisk,
     OfficeLocation? officeLocation,
     CommuteWindows? commuteWindows,
+    int? presenceRadiusM,
+    int? speedCutoffKmh,
   }) {
     return UserPreferences(
       weatherLimits: weatherLimits ?? this.weatherLimits,
       environmentalRisk: environmentalRisk ?? this.environmentalRisk,
       officeLocation: officeLocation ?? this.officeLocation,
       commuteWindows: commuteWindows ?? this.commuteWindows,
+      presenceRadiusM: presenceRadiusM ?? this.presenceRadiusM,
+      speedCutoffKmh: speedCutoffKmh ?? this.speedCutoffKmh,
     );
   }
 
@@ -70,7 +84,9 @@ class UserPreferences {
     return weatherLimits.isValid &&
         environmentalRisk.isValid &&
         officeLocation.isValid &&
-        commuteWindows.isValid;
+        commuteWindows.isValid &&
+        presenceRadiusM > 0 &&
+        speedCutoffKmh >= 0;
   }
 
   @override
@@ -80,7 +96,9 @@ class UserPreferences {
         other.weatherLimits == weatherLimits &&
         other.environmentalRisk == environmentalRisk &&
         other.officeLocation == officeLocation &&
-        other.commuteWindows == commuteWindows;
+        other.commuteWindows == commuteWindows &&
+        other.presenceRadiusM == presenceRadiusM &&
+        other.speedCutoffKmh == speedCutoffKmh;
   }
 
   @override
@@ -88,12 +106,14 @@ class UserPreferences {
     return weatherLimits.hashCode ^
         environmentalRisk.hashCode ^
         officeLocation.hashCode ^
-        commuteWindows.hashCode;
+        commuteWindows.hashCode ^
+        presenceRadiusM.hashCode ^
+        speedCutoffKmh.hashCode;
   }
 
   @override
   String toString() {
-    return 'UserPreferences(weatherLimits: $weatherLimits, environmentalRisk: $environmentalRisk, officeLocation: $officeLocation, commuteWindows: $commuteWindows)';
+    return 'UserPreferences(weatherLimits: $weatherLimits, environmentalRisk: $environmentalRisk, officeLocation: $officeLocation, commuteWindows: $commuteWindows, presenceRadiusM: $presenceRadiusM, speedCutoffKmh: $speedCutoffKmh)';
   }
 }
 

--- a/ride_aware_frontend/lib/services/api_service.dart
+++ b/ride_aware_frontend/lib/services/api_service.dart
@@ -31,11 +31,16 @@ class ApiService {
         throw Exception('Invalid threshold values');
       }
 
+      final now = DateTime.now();
+      final date =
+          '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
       final requestBody = {
         'device_id': deviceId,
-        'date': DateTime.now().toUtc().toIso8601String().split('T').first,
+        'date': date,
         'start_time': preferences.commuteWindows.start,
         'end_time': preferences.commuteWindows.end,
+        'presence_radius_m': preferences.presenceRadiusM,
+        'speed_cutoff_kmh': preferences.speedCutoffKmh,
         'weather_limits': preferences.weatherLimits.toJson(),
         'office_location': preferences.officeLocation.toJson(),
       };


### PR DESCRIPTION
## Summary
- store thresholds with presence radius and speed cutoff and snapshot them in ride history
- expose `GET /thresholds/{device_id}/current` for latest preferences
- send local date and new commute parameters from the Flutter app

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c4b23d56883289340a3bf20d7fe9b