### PR TITLE
Fix commute date handling and alert timing

### DIFF
--- a/ride_aware_backend/services/alert_service.py
+++ b/ride_aware_backend/services/alert_service.py
@@ -41,7 +41,7 @@ async def schedule_pre_route_alert(threshold: Thresholds) -> None:
     alert_dt = start_dt - timedelta(hours=3)
 
     async def worker():
-        delay = (alert_dt - datetime.utcnow()).total_seconds()
+        delay = (alert_dt - datetime.now()).total_seconds()
         if delay > 0:
             await asyncio.sleep(delay)
         await _check_and_notify(threshold)

--- a/ride_aware_frontend/lib/services/api_service.dart
+++ b/ride_aware_frontend/lib/services/api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import '../models/user_preferences.dart';
 import '../models/route_model.dart'; // Import RouteModel
@@ -31,10 +32,21 @@ class ApiService {
         throw Exception('Invalid threshold values');
       }
 
-      final now = DateTime.now();
-      final date =
-          '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
-      final requestBody = {
+        final now = DateTime.now();
+        final rideStart = preferences.commuteWindows.startLocal;
+        final todayStart = DateTime(
+          now.year,
+          now.month,
+          now.day,
+          rideStart.hour,
+          rideStart.minute,
+        );
+        final scheduled = now.isBefore(todayStart)
+            ? todayStart
+            : todayStart.add(const Duration(days: 1));
+        final date =
+            '${scheduled.year.toString().padLeft(4, '0')}-${scheduled.month.toString().padLeft(2, '0')}-${scheduled.day.toString().padLeft(2, '0')}';
+        final requestBody = {
         'device_id': deviceId,
         'date': date,
         'start_time': preferences.commuteWindows.start,

--- a/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
+++ b/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
@@ -83,15 +83,17 @@ class UpcomingCommuteViewModel extends ChangeNotifier {
 
   DateTime _nextCommuteTime(UserPreferences prefs) {
     final now = DateTime.now();
-    TimeOfDay rideTime = prefs.commuteWindows.startLocal;
-    DateTime scheduled = DateTime(
+    final rideTime = prefs.commuteWindows.startLocal;
+    final todayStart = DateTime(
       now.year,
       now.month,
-      now.day + 1,
+      now.day,
       rideTime.hour,
       rideTime.minute,
     );
-    return scheduled;
+    return now.isBefore(todayStart)
+        ? todayStart
+        : todayStart.add(const Duration(days: 1));
   }
 
   List<GeoPoint> _sampleRoute(RouteModel route, {int samples = 5}) {


### PR DESCRIPTION
## Summary
- compute next commute for same-day when start time remains
- align threshold date with scheduling logic
- use local time for alert scheduling delay

## Testing
- `pytest`
- `dart format ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart ride_aware_frontend/lib/services/api_service.dart` *(command not found: dart)*
- `flutter --version` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689cb8b49a148328ab3b86c17329d7a4