### PR TITLE
Add timezone-aware weather scheduling and actionable pre-ride alerts

### DIFF
--- a/ride_aware_backend/controllers/ride_history_controller.py
+++ b/ride_aware_backend/controllers/ride_history_controller.py
@@ -37,7 +37,15 @@ async def create_history_entry(
         {"threshold_id": threshold_id}, {"$setOnInsert": doc}, upsert=True
     )
     await schedule_weather_collection(
-        device_id, threshold_id, date, start_time, end_time
+        device_id,
+        threshold_id,
+        date,
+        start_time,
+        end_time,
+        timezone_str=threshold_snapshot.get("timezone", "UTC"),
+        interval_minutes=threshold_snapshot.get(
+            "weather_snapshot_interval_minutes", 10
+        ),
     )
 
 

--- a/ride_aware_backend/models/thresholds.py
+++ b/ride_aware_backend/models/thresholds.py
@@ -32,6 +32,8 @@ class Thresholds(BaseModel):
     date: DateStr
     start_time: TimeStr
     end_time: TimeStr
+    timezone: str = Field(default="UTC", min_length=1)
+    weather_snapshot_interval_minutes: int = Field(default=10, ge=1)
     presence_radius_m: int = Field(default=100, ge=1)
     speed_cutoff_kmh: int = Field(default=5, ge=0)
     weather_limits: WeatherLimits

--- a/ride_aware_backend/services/threshold_eval.py
+++ b/ride_aware_backend/services/threshold_eval.py
@@ -1,0 +1,110 @@
+"""Utilities for evaluating forecasts against user limits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class Breach:
+    """Represents a single metric that exceeds a user's limit."""
+
+    metric: str
+    value: float
+    limit: float
+    severity: str
+    advice: str
+
+
+def evaluate_forecast_point(point: Dict, limits: Dict) -> List[Breach]:
+    """Compare a forecast point against weather limits and return breaches."""
+
+    out: List[Breach] = []
+
+    temp = point.get("temp")
+    if temp is not None:
+        if "min_temperature" in limits and temp < limits["min_temperature"]:
+            out.append(
+                Breach(
+                    metric="temp",
+                    value=temp,
+                    limit=float(limits["min_temperature"]),
+                    severity="warn",
+                    advice="It will feel cold; consider thermal layers and gloves.",
+                )
+            )
+        if "max_temperature" in limits and temp > limits["max_temperature"]:
+            out.append(
+                Breach(
+                    metric="temp",
+                    value=temp,
+                    limit=float(limits["max_temperature"]),
+                    severity="warn",
+                    advice="It will be hot; hydrate well and wear breathable kit.",
+                )
+            )
+
+    wind = point.get("wind_speed")
+    if wind is not None and "max_wind_speed" in limits:
+        limit = float(limits["max_wind_speed"])
+        if wind > limit:
+            sev = "alert" if wind > limit * 1.2 else "warn"
+            out.append(
+                Breach(
+                    metric="wind_speed",
+                    value=wind,
+                    limit=limit,
+                    severity=sev,
+                    advice="Wind is high; travel light, avoid loose bags, allow extra time.",
+                )
+            )
+
+    rain = point.get("rain")
+    if rain is not None and "max_rain_intensity" in limits:
+        if rain > float(limits["max_rain_intensity"]):
+            out.append(
+                Breach(
+                    metric="rain",
+                    value=rain,
+                    limit=float(limits["max_rain_intensity"]),
+                    severity="warn",
+                    advice="Expect rain; waterproof jacket and mudguards recommended.",
+                )
+            )
+
+    uv = point.get("uvi")
+    if uv is not None and "max_uv_index" in limits:
+        if uv > float(limits["max_uv_index"]):
+            out.append(
+                Breach(
+                    metric="uvi",
+                    value=uv,
+                    limit=float(limits["max_uv_index"]),
+                    severity="info",
+                    advice="High UV; use sunscreen and glasses.",
+                )
+            )
+
+    return out
+
+
+def summarize_breaches(hourly_breaches: List[List[Breach]]) -> str:
+    """Combine breaches into a short, de-duplicated advisory string."""
+
+    flat = [b for lst in hourly_breaches for b in lst]
+    if not flat:
+        return ""
+
+    priority = {"alert": 0, "warn": 1, "info": 2}
+    flat.sort(key=lambda b: priority[b.severity])
+
+    seen = set()
+    ordered: List[str] = []
+    for b in flat:
+        if b.advice not in seen:
+            ordered.append(b.advice)
+            seen.add(b.advice)
+
+    return " • ".join(ordered)
+

--- a/ride_aware_backend/tests/controllers/test_ride_history_controller.py
+++ b/ride_aware_backend/tests/controllers/test_ride_history_controller.py
@@ -39,6 +39,8 @@ def test_create_history_entry_sets_defaults_on_insert(monkeypatch):
     assert on_insert["feedback"] is None
     assert on_insert["threshold"]["presence_radius_m"] == 100
     assert upsert is True
-    sched.assert_awaited_once_with(
-        "dev1", "th1", "2024-01-01", "08:00", "09:00"
-    )
+    sched.assert_awaited_once()
+    args, kwargs = sched.call_args
+    assert args == ("dev1", "th1", "2024-01-01", "08:00", "09:00")
+    assert kwargs["timezone_str"] == "UTC"
+    assert kwargs["interval_minutes"] == 10

--- a/ride_aware_frontend/lib/helpers/schedule.dart
+++ b/ride_aware_frontend/lib/helpers/schedule.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Choose the next scheduled start date based on the provided start time.
+DateTime pickScheduledStart(DateTime now, TimeOfDay startLocal) {
+  final todayStart = DateTime(
+    now.year,
+    now.month,
+    now.day,
+    startLocal.hour,
+    startLocal.minute,
+  );
+  return now.isBefore(todayStart) ? todayStart : todayStart.add(const Duration(days: 1));
+}
+
+/// Format a [DateTime] as `YYYY-MM-DD`.
+String yyyymmdd(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+extension TimeOfDayX on TimeOfDay {
+  /// Format the time as `HH:mm`.
+  String format24h() =>
+      '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
+}
+

--- a/ride_aware_frontend/lib/models/user_preferences.dart
+++ b/ride_aware_frontend/lib/models/user_preferences.dart
@@ -8,6 +8,7 @@ class UserPreferences {
   final CommuteWindows commuteWindows;
   final int presenceRadiusM;
   final int speedCutoffKmh;
+  final String timezone;
 
   const UserPreferences({
     required this.weatherLimits,
@@ -16,6 +17,7 @@ class UserPreferences {
     required this.commuteWindows,
     this.presenceRadiusM = 100,
     this.speedCutoffKmh = 5,
+    this.timezone = 'Europe/London',
   });
 
   // Default preferences for first-time users
@@ -27,6 +29,7 @@ class UserPreferences {
       commuteWindows: CommuteWindows.defaultValues(),
       presenceRadiusM: 100,
       speedCutoffKmh: 5,
+      timezone: 'Europe/London',
     );
   }
 
@@ -44,6 +47,7 @@ class UserPreferences {
       }),
       presenceRadiusM: json['presence_radius_m'] ?? 100,
       speedCutoffKmh: json['speed_cutoff_kmh'] ?? 5,
+      timezone: json['timezone'] ?? 'Europe/London',
     );
   }
 
@@ -57,6 +61,7 @@ class UserPreferences {
       'end_time': commuteWindows.end,
       'presence_radius_m': presenceRadiusM,
       'speed_cutoff_kmh': speedCutoffKmh,
+      'timezone': timezone,
     };
   }
 
@@ -68,6 +73,7 @@ class UserPreferences {
     CommuteWindows? commuteWindows,
     int? presenceRadiusM,
     int? speedCutoffKmh,
+    String? timezone,
   }) {
     return UserPreferences(
       weatherLimits: weatherLimits ?? this.weatherLimits,
@@ -76,6 +82,7 @@ class UserPreferences {
       commuteWindows: commuteWindows ?? this.commuteWindows,
       presenceRadiusM: presenceRadiusM ?? this.presenceRadiusM,
       speedCutoffKmh: speedCutoffKmh ?? this.speedCutoffKmh,
+      timezone: timezone ?? this.timezone,
     );
   }
 
@@ -98,7 +105,8 @@ class UserPreferences {
         other.officeLocation == officeLocation &&
         other.commuteWindows == commuteWindows &&
         other.presenceRadiusM == presenceRadiusM &&
-        other.speedCutoffKmh == speedCutoffKmh;
+        other.speedCutoffKmh == speedCutoffKmh &&
+        other.timezone == timezone;
   }
 
   @override
@@ -108,12 +116,14 @@ class UserPreferences {
         officeLocation.hashCode ^
         commuteWindows.hashCode ^
         presenceRadiusM.hashCode ^
-        speedCutoffKmh.hashCode;
+        speedCutoffKmh.hashCode ^
+        timezone.hashCode;
   }
 
   @override
   String toString() {
-    return 'UserPreferences(weatherLimits: $weatherLimits, environmentalRisk: $environmentalRisk, officeLocation: $officeLocation, commuteWindows: $commuteWindows, presenceRadiusM: $presenceRadiusM, speedCutoffKmh: $speedCutoffKmh)';
+    // ignore: lines_longer_than_80_chars
+    return 'UserPreferences(weatherLimits: $weatherLimits, environmentalRisk: $environmentalRisk, officeLocation: $officeLocation, commuteWindows: $commuteWindows, presenceRadiusM: $presenceRadiusM, speedCutoffKmh: $speedCutoffKmh, timezone: $timezone)';
   }
 }
 

--- a/ride_aware_frontend/lib/services/api_service.dart
+++ b/ride_aware_frontend/lib/services/api_service.dart
@@ -3,8 +3,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import '../models/user_preferences.dart';
-import '../models/route_model.dart'; // Import RouteModel
+import '../models/route_model.dart';
 import '../models/ride_history_entry.dart';
+import '../helpers/schedule.dart';
 import 'device_id_service.dart';
 import 'preferences_service.dart';
 
@@ -32,25 +33,15 @@ class ApiService {
         throw Exception('Invalid threshold values');
       }
 
-        final now = DateTime.now();
-        final rideStart = preferences.commuteWindows.startLocal;
-        final todayStart = DateTime(
-          now.year,
-          now.month,
-          now.day,
-          rideStart.hour,
-          rideStart.minute,
-        );
-        final scheduled = now.isBefore(todayStart)
-            ? todayStart
-            : todayStart.add(const Duration(days: 1));
-        final date =
-            '${scheduled.year.toString().padLeft(4, '0')}-${scheduled.month.toString().padLeft(2, '0')}-${scheduled.day.toString().padLeft(2, '0')}';
-        final requestBody = {
+      final now = DateTime.now();
+      final scheduledStart =
+          pickScheduledStart(now, preferences.commuteWindows.startLocal);
+      final requestBody = {
         'device_id': deviceId,
-        'date': date,
-        'start_time': preferences.commuteWindows.start,
-        'end_time': preferences.commuteWindows.end,
+        'date': yyyymmdd(scheduledStart),
+        'start_time': preferences.commuteWindows.startLocal.format24h(),
+        'end_time': preferences.commuteWindows.endLocal.format24h(),
+        'timezone': preferences.timezone,
         'presence_radius_m': preferences.presenceRadiusM,
         'speed_cutoff_kmh': preferences.speedCutoffKmh,
         'weather_limits': preferences.weatherLimits.toJson(),


### PR DESCRIPTION
## Summary
- collect weather snapshots only during the ride window using timezone-aware scheduling
- evaluate forecasts against rider limits to craft actionable pre-ride alerts
- expose timezone in preferences and send it with threshold submissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc04f35f08328ab5b7db24a230e8b