### PR TITLE
Add feedback reminder scheduling

### DIFF
--- a/ride_aware_backend/controllers/threshold_controller.py
+++ b/ride_aware_backend/controllers/threshold_controller.py
@@ -5,7 +5,10 @@ from models.thresholds import Thresholds
 from services.db import thresholds_collection
 from controllers.feedback_controller import create_feedback_entry
 from controllers.ride_history_controller import create_history_entry
-from services.alert_service import schedule_pre_route_alert
+from services.alert_service import (
+    schedule_pre_route_alert,
+    schedule_feedback_reminder,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -49,6 +52,7 @@ async def upsert_threshold(threshold: Thresholds) -> dict:
         device_id, threshold_id_str, date, start_time, end_time, data
     )
     await schedule_pre_route_alert(threshold)
+    await schedule_feedback_reminder(threshold)
 
     logger.info(
         "Thresholds upserted for device %s on %s from %s to %s",

--- a/ride_aware_backend/tests/controllers/test_threshold_controller.py
+++ b/ride_aware_backend/tests/controllers/test_threshold_controller.py
@@ -48,6 +48,10 @@ def test_upsert_threshold_insert(monkeypatch):
     monkeypatch.setattr(threshold_controller, "create_history_entry", create_hist)
     alert = AsyncMock()
     monkeypatch.setattr(threshold_controller, "schedule_pre_route_alert", alert)
+    reminder = AsyncMock()
+    monkeypatch.setattr(
+        threshold_controller, "schedule_feedback_reminder", reminder
+    )
 
     result = asyncio.run(threshold_controller.upsert_threshold(thresholds))
 
@@ -63,6 +67,7 @@ def test_upsert_threshold_insert(monkeypatch):
         thresholds.model_dump(mode="json"),
     )
     alert.assert_awaited_once()
+    reminder.assert_awaited_once()
     assert result["threshold_id"] == "id"
     assert result["status"] == "ok"
 
@@ -86,6 +91,10 @@ def test_upsert_threshold_update(monkeypatch):
     monkeypatch.setattr(threshold_controller, "create_history_entry", create_hist)
     alert = AsyncMock()
     monkeypatch.setattr(threshold_controller, "schedule_pre_route_alert", alert)
+    reminder = AsyncMock()
+    monkeypatch.setattr(
+        threshold_controller, "schedule_feedback_reminder", reminder
+    )
 
     result = asyncio.run(threshold_controller.upsert_threshold(thresholds))
 
@@ -101,6 +110,7 @@ def test_upsert_threshold_update(monkeypatch):
         thresholds.model_dump(mode="json"),
     )
     alert.assert_awaited_once()
+    reminder.assert_awaited_once()
     assert result["threshold_id"] == "existing"
     assert result["status"] == "ok"
 


### PR DESCRIPTION
## Summary
- schedule feedback reminders after commute ends
- trigger feedback reminder when threshold is upserted
- test threshold controller schedules reminders

## Testing
- `cd ride_aware_backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc47930a483289615bd0e200dbf55