### PR TITLE
feat: handle push notifications

### DIFF
--- a/ride_aware_frontend/lib/main.dart
+++ b/ride_aware_frontend/lib/main.dart
@@ -1,29 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 
 import 'app_initializer.dart';
-import 'services/notification_service.dart';
 import 'theme/app_theme.dart';
-
-// Top-level function to handle background messages
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  // If you're going to use other Firebase services in the background, such as Firestore,
-  // make sure you call `initializeApp` before using other Firebase services.
-  await Firebase.initializeApp();
-
-  print("📱 Background Message: ${message.notification?.title}");
-  print("📱 Background Body: ${message.notification?.body}");
-}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Initialize Firebase
   await Firebase.initializeApp();
-
-  // Set up background message handler
-  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
   runApp(const ActiveCommuterApp());
 }


### PR DESCRIPTION
## Summary
- handle FCM messages in NotificationService and persist feedback reminders
- simplify main initialization and register Firebase only

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccebbc3d0832898213c004737fbf6