### PR TITLE
Allow multiple ride histories per threshold

### DIFF
--- a/ride_aware_backend/controllers/ride_history_controller.py
+++ b/ride_aware_backend/controllers/ride_history_controller.py
@@ -34,7 +34,13 @@ async def create_history_entry(
         "feedback": None,
     }
     await ride_history_collection.update_one(
-        {"threshold_id": threshold_id}, {"$setOnInsert": doc}, upsert=True
+        {
+            "threshold_id": threshold_id,
+            "date": date,
+            "start_time": start_time,
+        },
+        {"$setOnInsert": doc},
+        upsert=True,
     )
     await schedule_weather_collection(
         device_id,
@@ -53,7 +59,12 @@ async def save_ride(entry: RideHistoryEntry) -> dict:
     try:
         doc = entry.model_dump(mode="json")
         await ride_history_collection.update_one(
-            {"device_id": entry.device_id, "threshold_id": entry.threshold_id},
+            {
+                "device_id": entry.device_id,
+                "threshold_id": entry.threshold_id,
+                "date": entry.date.isoformat(),
+                "start_time": entry.start_time,
+            },
             {"$set": doc},
             upsert=True,
         )

--- a/ride_aware_backend/services/db.py
+++ b/ride_aware_backend/services/db.py
@@ -33,7 +33,7 @@ async def init_db() -> None:
         partialFilterExpression={"threshold_id": {"$exists": True}}
     )
     await ride_history_collection.create_index(
-        [("date", 1), ("threshold_id", 1)], unique=True
+        [("date", 1), ("threshold_id", 1), ("start_time", 1)], unique=True
     )
     await weather_history_collection.create_index(
         [

--- a/ride_aware_backend/tests/controllers/test_ride_history_controller.py
+++ b/ride_aware_backend/tests/controllers/test_ride_history_controller.py
@@ -1,5 +1,4 @@
 import asyncio
-import asyncio
 from unittest.mock import AsyncMock
 
 from controllers import ride_history_controller
@@ -34,7 +33,11 @@ def test_create_history_entry_sets_defaults_on_insert(monkeypatch):
 
     assert dummy.args is not None
     filter_doc, update_doc, upsert = dummy.args
-    assert filter_doc == {"threshold_id": "th1"}
+    assert filter_doc == {
+        "threshold_id": "th1",
+        "date": "2024-01-01",
+        "start_time": "08:00",
+    }
     on_insert = update_doc["$setOnInsert"]
     assert on_insert["feedback"] is None
     assert on_insert["threshold"]["presence_radius_m"] == 100


### PR DESCRIPTION
## Summary
- ensure ride history records are keyed by threshold, date, and start time so multiple rides are stored
- update database index and save logic accordingly
- adjust unit test to reflect new unique key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd70771e08328a2e780912c50cf09