### PR TITLE
Show feedback card shortly after ride

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -63,7 +63,9 @@ class _DashboardScreenState extends State<DashboardScreen>
       GlobalKey<UpcomingCommuteAlertState>();
 
   FeedbackWindow _windowFor(RideSlot current, RideSlot? next) {
-    final showAt = current.endUtc.toLocal().add(const Duration(hours: 1));
+    // Show the feedback card shortly after a ride ends rather than waiting
+    // an hour. This ensures riders see the feedback prompt promptly.
+    final showAt = current.endUtc.toLocal().add(const Duration(minutes: 1));
     final hideAt = next == null
         ? null
         : next.startUtc.toLocal().subtract(const Duration(minutes: 1));


### PR DESCRIPTION
## Summary
- Display post-ride feedback card one minute after ride end instead of waiting an hour

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cd9bf080c83288bb29f55b4dbcb29