### PR TITLE
Fix async weather history scheduling

### DIFF
--- a/ride_aware_backend/services/weather_history_service.py
+++ b/ride_aware_backend/services/weather_history_service.py
@@ -91,20 +91,19 @@ async def schedule_weather_collection(
     start_dt = datetime.combine(ride_date, parse_time(start_time), tzinfo=tz)
     end_dt = datetime.combine(ride_date, parse_time(end_time), tzinfo=tz)
 
-    now = datetime.now(tz)
-    if now >= end_dt:
-        return
-
-    if now < start_dt:
-        await asyncio.sleep((start_dt - now).total_seconds())
-
-    now = datetime.now(tz)
-    if now >= end_dt:
-        return
-
     interval = timedelta(minutes=interval_minutes)
 
     async def worker():
+        now = datetime.now(tz)
+        if now >= end_dt:
+            return
+
+        if now < start_dt:
+            await asyncio.sleep((start_dt - now).total_seconds())
+            now = datetime.now(tz)
+            if now >= end_dt:
+                return
+
         curr = now
         while curr < end_dt:
             await _record_snapshot(device_id, threshold_id, lat, lon, curr)


### PR DESCRIPTION
## Summary
- prevent weather history scheduling from blocking request handling
- ensure ride snapshots collected asynchronously during rides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce3ef523c8328a7a0f149e7f0dd5b