### PR TITLE
Refactor time handling to use device local time

### DIFF
--- a/ride_aware_backend/controllers/feedback_controller.py
+++ b/ride_aware_backend/controllers/feedback_controller.py
@@ -43,7 +43,7 @@ async def create_feedback_entry(device_id: str, threshold_id: str) -> None:
     doc = {
         "device_id": device_id,
         "threshold_id": threshold_id,
-        "created_at": datetime.utcnow().isoformat(),
+        "created_at": datetime.now().isoformat(),
     }
     await feedback_collection.update_one(
         {"threshold_id": threshold_id}, {"$setOnInsert": doc}, upsert=True

--- a/ride_aware_backend/controllers/ride_history_controller.py
+++ b/ride_aware_backend/controllers/ride_history_controller.py
@@ -48,7 +48,7 @@ async def create_history_entry(
         date,
         start_time,
         end_time,
-        timezone_str=threshold_snapshot.get("timezone", "UTC"),
+        timezone_str=threshold_snapshot.get("timezone"),
         interval_minutes=threshold_snapshot.get(
             "weather_snapshot_interval_minutes", 10
         ),
@@ -95,7 +95,7 @@ async def save_ride_after_delay(
 
 
 async def fetch_rides(device_id: str, last_days: int = 30):
-    since = datetime.utcnow().date() - timedelta(days=last_days)
+    since = datetime.now().date() - timedelta(days=last_days)
     cursor = ride_history_collection.find(
         {"device_id": device_id, "date": {"$gte": since.isoformat()}}
     ).sort("date", -1)

--- a/ride_aware_backend/controllers/threshold_controller.py
+++ b/ride_aware_backend/controllers/threshold_controller.py
@@ -111,7 +111,7 @@ async def get_thresholds(device_id: str, date: str, start_time: str, end_time: s
 
 
 async def get_current_threshold(device_id: str) -> dict:
-    today = datetime.utcnow().date().isoformat()
+    today = datetime.now().date().isoformat()
     doc = await thresholds_collection.find_one({"device_id": device_id, "date": today})
     if not doc:
         cursor = (

--- a/ride_aware_backend/models/thresholds.py
+++ b/ride_aware_backend/models/thresholds.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel, Field, condecimal, StringConstraints, ConfigDict
 from typing import Annotated, Optional
 
@@ -25,6 +26,11 @@ class OfficeLocation(BaseModel):
     longitude: condecimal(gt=-180, le=180, decimal_places=6)
 
 
+def _local_timezone() -> str:
+    tzinfo = datetime.now().astimezone().tzinfo
+    return getattr(tzinfo, "key", tzinfo.tzname(None))
+
+
 class Thresholds(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -32,7 +38,7 @@ class Thresholds(BaseModel):
     date: DateStr
     start_time: TimeStr
     end_time: TimeStr
-    timezone: str = Field(default="UTC", min_length=1)
+    timezone: str = Field(default_factory=_local_timezone, min_length=1)
     weather_snapshot_interval_minutes: int = Field(default=10, ge=1)
     presence_radius_m: int = Field(default=100, ge=1)
     speed_cutoff_kmh: int = Field(default=5, ge=0)

--- a/ride_aware_backend/services/alert_service.py
+++ b/ride_aware_backend/services/alert_service.py
@@ -43,7 +43,8 @@ async def _check_and_notify(threshold: Thresholds) -> None:
 async def schedule_pre_route_alert(threshold: Thresholds) -> None:
     """Schedule an alert three hours before commute start respecting timezone."""
 
-    tz = ZoneInfo(getattr(threshold, "timezone", "UTC"))
+    tz_name = getattr(threshold, "timezone", None) or datetime.now().astimezone().tzinfo.key
+    tz = ZoneInfo(tz_name)
     ride_date = date.fromisoformat(threshold.date)
     start_dt = datetime.combine(ride_date, parse_time(threshold.start_time), tzinfo=tz)
     alert_dt = start_dt - timedelta(hours=3)
@@ -61,7 +62,8 @@ async def schedule_pre_route_alert(threshold: Thresholds) -> None:
 async def schedule_feedback_reminder(threshold: Thresholds) -> None:
     """Schedule a feedback reminder one hour after commute end."""
 
-    tz = ZoneInfo(getattr(threshold, "timezone", "UTC"))
+    tz_name = getattr(threshold, "timezone", None) or datetime.now().astimezone().tzinfo.key
+    tz = ZoneInfo(tz_name)
     ride_date = date.fromisoformat(threshold.date)
     end_dt = datetime.combine(
         ride_date, parse_time(threshold.end_time), tzinfo=tz

--- a/ride_aware_backend/services/forecast_cache_service.py
+++ b/ride_aware_backend/services/forecast_cache_service.py
@@ -10,7 +10,7 @@ async def save_hourly_forecasts(lat: float, lon: float, forecasts: List[Dict]) -
     doc = {
         "lat": lat,
         "lon": lon,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(),
         "forecasts": forecasts,
     }
     await forecasts_collection.insert_one(doc)

--- a/ride_aware_backend/services/weather_history_service.py
+++ b/ride_aware_backend/services/weather_history_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, date, timedelta, timezone
+from datetime import datetime, date, timedelta
 from typing import List, Dict
 from zoneinfo import ZoneInfo
 
@@ -51,7 +51,7 @@ async def _record_snapshot(
 ) -> None:
     """Fetch and store a single weather snapshot."""
 
-    weather = get_hourly_forecast(lat, lon, now.astimezone(timezone.utc))
+    weather = get_hourly_forecast(lat, lon, now)
     snap = RouteWeatherSnapshot(
         device_id=device_id,
         threshold_id=threshold_id,
@@ -68,7 +68,7 @@ async def schedule_weather_collection(
     start_time: str,
     end_time: str,
     *,
-    timezone_str: str = "UTC",
+    timezone_str: str | None = None,
     interval_minutes: int = 10,
 ) -> None:
     """Collect weather snapshots only during the ride window."""
@@ -86,7 +86,7 @@ async def schedule_weather_collection(
     lat = float(points[0]["latitude"])
     lon = float(points[0]["longitude"])
 
-    tz = ZoneInfo(timezone_str)
+    tz = ZoneInfo(timezone_str) if timezone_str else ZoneInfo(datetime.now().astimezone().tzinfo.key)
     ride_date = date.fromisoformat(date_str)
     start_dt = datetime.combine(ride_date, parse_time(start_time), tzinfo=tz)
     end_dt = datetime.combine(ride_date, parse_time(end_time), tzinfo=tz)

--- a/ride_aware_backend/services/wind_service.py
+++ b/ride_aware_backend/services/wind_service.py
@@ -95,7 +95,7 @@ async def compute_wind_directions(req: RouteRequest) -> List[WindResult]:
             {"lat": p.lat, "lon": p.lon} for p in req.points
         ],
         "sampled_winds": [r.dict() for r in results],
-        "timestamp": datetime.utcnow(),
+        "timestamp": datetime.now(),
     }
     try:
         await wind_collection.insert_one(record)

--- a/ride_aware_backend/tests/controllers/test_ride_history_controller.py
+++ b/ride_aware_backend/tests/controllers/test_ride_history_controller.py
@@ -45,5 +45,5 @@ def test_create_history_entry_sets_defaults_on_insert(monkeypatch):
     sched.assert_awaited_once()
     args, kwargs = sched.call_args
     assert args == ("dev1", "th1", "2024-01-01", "08:00", "09:00")
-    assert kwargs["timezone_str"] == "UTC"
+    assert kwargs["timezone_str"] is None
     assert kwargs["interval_minutes"] == 10

--- a/ride_aware_backend/tests/controllers/test_threshold_controller.py
+++ b/ride_aware_backend/tests/controllers/test_threshold_controller.py
@@ -166,7 +166,7 @@ def test_get_current_threshold_today(monkeypatch):
             "find": AsyncMock(),
         },
     )()
-    dummy_dt = type("D", (), {"utcnow": classmethod(lambda cls: datetime(2024, 1, 1))})
+    dummy_dt = type("D", (), {"now": classmethod(lambda cls: datetime(2024, 1, 1))})
     monkeypatch.setattr(threshold_controller, "datetime", dummy_dt)
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
 
@@ -198,7 +198,7 @@ def test_get_current_threshold_latest(monkeypatch):
             "find": lambda self, query: Cursor(),
         },
     )()
-    dummy_dt = type("D", (), {"utcnow": classmethod(lambda cls: datetime(2024, 1, 2))})
+    dummy_dt = type("D", (), {"now": classmethod(lambda cls: datetime(2024, 1, 2))})
     monkeypatch.setattr(threshold_controller, "datetime", dummy_dt)
     monkeypatch.setattr(threshold_controller, "thresholds_collection", collection)
 

--- a/ride_aware_frontend/lib/models/ride_history_entry.dart
+++ b/ride_aware_frontend/lib/models/ride_history_entry.dart
@@ -1,7 +1,7 @@
 class RideHistoryEntry {
   final String rideId;
-  final DateTime startUtc;
-  final DateTime endUtc;
+  final DateTime start;
+  final DateTime end;
   final String status;
   final Map<String, dynamic> summary;
   final Map<String, dynamic>? threshold;
@@ -10,8 +10,8 @@ class RideHistoryEntry {
 
   RideHistoryEntry({
     required this.rideId,
-    required this.startUtc,
-    required this.endUtc,
+    required this.start,
+    required this.end,
     required this.status,
     required this.summary,
     this.threshold,
@@ -19,13 +19,18 @@ class RideHistoryEntry {
     required this.weather,
   });
 
-  DateTime get localDate => startUtc.toLocal();
+  DateTime get localDate => start;
 
   factory RideHistoryEntry.fromJson(Map<String, dynamic> json) {
+    final date = json['date'] as String;
+    final startStr = json['start_time'] as String;
+    final endStr = json['end_time'] as String;
+    final start = DateTime.parse('${date}T$startStr');
+    final end = DateTime.parse('${date}T$endStr');
     return RideHistoryEntry(
       rideId: json['ride_id'] as String,
-      startUtc: DateTime.parse(json['start_utc'] as String),
-      endUtc: DateTime.parse(json['end_utc'] as String),
+      start: start,
+      end: end,
       status: json['status'] as String,
       summary: Map<String, dynamic>.from(json['summary'] as Map),
       threshold: json['threshold'] == null
@@ -40,8 +45,9 @@ class RideHistoryEntry {
 
   Map<String, dynamic> toJson() => {
         'ride_id': rideId,
-        'start_utc': startUtc.toUtc().toIso8601String(),
-        'end_utc': endUtc.toUtc().toIso8601String(),
+        'date': start.toIso8601String().split('T').first,
+        'start_time': '${start.hour.toString().padLeft(2, '0')}:${start.minute.toString().padLeft(2, '0')}',
+        'end_time': '${end.hour.toString().padLeft(2, '0')}:${end.minute.toString().padLeft(2, '0')}',
         'status': status,
         'summary': summary,
         if (threshold != null) 'threshold': threshold,
@@ -52,21 +58,21 @@ class RideHistoryEntry {
 }
 
 class WeatherPoint {
-  final DateTime tsUtc;
+  final DateTime timestamp;
   final num? tempC;
   final num? windMs;
   final String? cond;
-  WeatherPoint({required this.tsUtc, this.tempC, this.windMs, this.cond});
+  WeatherPoint({required this.timestamp, this.tempC, this.windMs, this.cond});
 
   factory WeatherPoint.fromJson(Map<String, dynamic> json) => WeatherPoint(
-        tsUtc: DateTime.parse(json['ts_utc'] as String),
+        timestamp: DateTime.parse(json['timestamp'] as String),
         tempC: json['temp_c'] as num?,
         windMs: json['wind_ms'] as num?,
         cond: json['cond'] as String?,
       );
 
   Map<String, dynamic> toJson() => {
-        'ts_utc': tsUtc.toUtc().toIso8601String(),
+        'timestamp': timestamp.toIso8601String(),
         if (tempC != null) 'temp_c': tempC,
         if (windMs != null) 'wind_ms': windMs,
         if (cond != null) 'cond': cond,

--- a/ride_aware_frontend/lib/models/ride_slot.dart
+++ b/ride_aware_frontend/lib/models/ride_slot.dart
@@ -1,8 +1,8 @@
 class RideSlot {
-  final DateTime startUtc;
-  final DateTime endUtc;
+  final DateTime start;
+  final DateTime end;
   final String rideId;
-  RideSlot({required this.startUtc, required this.endUtc, required this.rideId});
+  RideSlot({required this.start, required this.end, required this.rideId});
 }
 
 class FeedbackWindow {
@@ -12,11 +12,10 @@ class FeedbackWindow {
 }
 
 FeedbackWindow windowFor(RideSlot current, RideSlot? next) {
-  final showAt = current.endUtc.toLocal().add(const Duration(hours: 1));
+  final showAt = current.end.add(const Duration(hours: 1));
   final hideAt = (next == null
-          ? DateTime.fromMillisecondsSinceEpoch(8640000000000000, isUtc: true)
-          : next.startUtc)
-      .toLocal()
+          ? DateTime.fromMillisecondsSinceEpoch(8640000000000000)
+          : next.start)
       .subtract(const Duration(minutes: 1));
   return FeedbackWindow(showAt: showAt, hideAt: hideAt);
 }

--- a/ride_aware_frontend/lib/models/user_preferences.dart
+++ b/ride_aware_frontend/lib/models/user_preferences.dart
@@ -395,10 +395,10 @@ class OfficeLocation {
 }
 
 class CommuteWindows {
-  /// Stored in UTC format (HH:mm)
+  /// Stored in local time (HH:mm)
   final String start;
 
-  /// Stored in UTC format (HH:mm)
+  /// Stored in local time (HH:mm)
   final String end;
 
   const CommuteWindows._({required this.start, required this.end});
@@ -411,7 +411,7 @@ class CommuteWindows {
   }
 
   factory CommuteWindows.defaultValues() {
-    // Default times in UTC (assuming user is in UTC+0 initially)
+    // Default times in local time
     return CommuteWindows(start: '07:30', end: '17:30');
   }
 
@@ -450,66 +450,29 @@ class CommuteWindows {
     return timeRegex.hasMatch(time);
   }
 
-  /// Convert UTC time string to local [TimeOfDay]
-  TimeOfDay utcToLocalTimeOfDay(String utcTimeString) {
+  /// Convert [TimeOfDay] to storage string
+  static String localTimeOfDayToString(TimeOfDay localTime) {
+    return '${localTime.hour.toString().padLeft(2, '0')}:${localTime.minute.toString().padLeft(2, '0')}';
+  }
+
+  TimeOfDay _stringToTimeOfDay(String time) {
     try {
-      final parts = utcTimeString.split(':');
+      final parts = time.split(':');
       if (parts.length == 2) {
-        final utcHour = int.parse(parts[0]);
-        final utcMinute = int.parse(parts[1]);
-
-        // Create a DateTime in UTC for today with the specified time
-        final now = DateTime.now();
-        final utcDateTime = DateTime.utc(
-          now.year,
-          now.month,
-          now.day,
-          utcHour,
-          utcMinute,
-        );
-
-        // Convert to local time
-        final localDateTime = utcDateTime.toLocal();
-
         return TimeOfDay(
-          hour: localDateTime.hour,
-          minute: localDateTime.minute,
+          hour: int.parse(parts[0]),
+          minute: int.parse(parts[1]),
         );
       }
-    } catch (e) {
-      // If parsing fails, return default
-    }
+    } catch (_) {}
     return const TimeOfDay(hour: 7, minute: 30);
   }
 
-  /// Convert local [TimeOfDay] to UTC time string
-  static String localTimeOfDayToUtc(TimeOfDay localTime) {
-    try {
-      // Create a DateTime in local time for today with the specified time
-      final now = DateTime.now();
-      final localDateTime = DateTime(
-        now.year,
-        now.month,
-        now.day,
-        localTime.hour,
-        localTime.minute,
-      );
-
-      // Convert to UTC
-      final utcDateTime = localDateTime.toUtc();
-
-      return '${utcDateTime.hour.toString().padLeft(2, '0')}:${utcDateTime.minute.toString().padLeft(2, '0')}';
-    } catch (e) {
-      // If conversion fails, return the original time as string
-      return '${localTime.hour.toString().padLeft(2, '0')}:${localTime.minute.toString().padLeft(2, '0')}';
-    }
-  }
-
   /// Get route start time in the local timezone
-  TimeOfDay get startLocal => utcToLocalTimeOfDay(start);
+  TimeOfDay get startLocal => _stringToTimeOfDay(start);
 
   /// Get route end time in the local timezone
-  TimeOfDay get endLocal => utcToLocalTimeOfDay(end);
+  TimeOfDay get endLocal => _stringToTimeOfDay(end);
 
   @override
   bool operator ==(Object other) {
@@ -526,6 +489,6 @@ class CommuteWindows {
 
   @override
   String toString() {
-    return 'CommuteWindows(start: $start UTC, end: $end UTC)';
+    return 'CommuteWindows(start: $start, end: $end)';
   }
 }

--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -16,15 +16,15 @@ import 'package:flutter/material.dart';
 
 class RideSlot {
   final String rideId;
-  final DateTime startUtc;
-  final DateTime endUtc;
+  final DateTime start;
+  final DateTime end;
   final Map<String, dynamic>? threshold;
   final List<WeatherPoint> weather;
 
   RideSlot({
     required this.rideId,
-    required this.startUtc,
-    required this.endUtc,
+    required this.start,
+    required this.end,
     this.threshold,
     this.weather = const <WeatherPoint>[],
   });
@@ -64,12 +64,11 @@ class _DashboardScreenState extends State<DashboardScreen>
       GlobalKey<UpcomingCommuteAlertState>();
 
   FeedbackWindow _windowFor(RideSlot current, RideSlot? next) {
-    // Show the feedback card shortly after a ride ends rather than waiting
-    // an hour. This ensures riders see the feedback prompt promptly.
-    final showAt = current.endUtc.toLocal().add(const Duration(minutes: 1));
+    // Feedback card appears one hour after ride end and hides one minute before next ride
+    final showAt = current.end.add(const Duration(hours: 1));
     final hideAt = next == null
         ? null
-        : next.startUtc.toLocal().subtract(const Duration(minutes: 1));
+        : next.start.subtract(const Duration(minutes: 1));
     return FeedbackWindow(showAt: showAt, hideAt: hideAt);
   }
 
@@ -282,14 +281,14 @@ class _DashboardScreenState extends State<DashboardScreen>
               onThresholdUpdated: _loadPrefs,
 
               onRideStarted: (
-                  String rideId, DateTime startUtc, Map<String, dynamic> threshold) async {
+                String rideId, DateTime start, Map<String, dynamic> threshold) async {
                 // No-op for now; could persist active ride
               },
 
               onRideEnded: (
                   String rideId,
-                  DateTime startUtc,
-                  DateTime endUtc,
+                  DateTime start,
+                  DateTime end,
                   String status,
                   Map<String, dynamic> summary,
                   Map<String, dynamic> threshold,
@@ -298,8 +297,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                     weatherHistory.map((e) => WeatherPoint.fromJson(e)).toList();
                 final entry = RideHistoryEntry(
                   rideId: rideId,
-                  startUtc: startUtc,
-                  endUtc: endUtc,
+                  start: start,
+                  end: end,
                   status: status,
                   summary: summary,
                   threshold: threshold,
@@ -313,8 +312,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                 setState(() {
                   _pendingRide = RideSlot(
                     rideId: rideId,
-                    startUtc: startUtc,
-                    endUtc: endUtc,
+                    start: start,
+                    end: end,
                     threshold: threshold,
                     weather: weatherPoints,
                   );

--- a/ride_aware_frontend/lib/screens/history_screen.dart
+++ b/ride_aware_frontend/lib/screens/history_screen.dart
@@ -83,8 +83,8 @@ class _HistoryScreenState extends State<HistoryScreen> {
                     itemCount: entries.length,
                     itemBuilder: (context, index) {
                       final e = entries[index];
-                      final start = e.startUtc.toLocal();
-                      final end = e.endUtc.toLocal();
+                      final start = e.start;
+                      final end = e.end;
                       return Card(
                         color: _statusColor(e.status),
                         margin: const EdgeInsets.symmetric(

--- a/ride_aware_frontend/lib/screens/preferences_screen.dart
+++ b/ride_aware_frontend/lib/screens/preferences_screen.dart
@@ -50,7 +50,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   final _officeLatController = TextEditingController();
   final _officeLonController = TextEditingController();
 
-  // Route time variables (displayed in local time, stored as UTC)
+// Route time variables (displayed and stored in local time)
   TimeOfDay _routeStartTime = const TimeOfDay(hour: 7, minute: 30);
   TimeOfDay _routeEndTime = const TimeOfDay(hour: 17, minute: 30);
 
@@ -132,21 +132,16 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
           .toStringAsFixed(6);
     }
 
-    // Populate route times - convert from UTC to local time for display
+    // Populate route times (stored and displayed in local time)
     _routeStartTime = preferences.commuteWindows.startLocal;
     _routeEndTime = preferences.commuteWindows.endLocal;
 
     if (kDebugMode) {
-      print('🕐 Time Conversion Debug:');
-      print('   Stored Route Start UTC: ${preferences.commuteWindows.start}');
-      print(
-        '   Displayed Start Local: ${_formatTimeOfDay(_routeStartTime)}',
-      );
-      print('   Stored Route End UTC: ${preferences.commuteWindows.end}');
-      print(
-        '   Displayed End Local: ${_formatTimeOfDay(_routeEndTime)}',
-      );
-      print('   Current Timezone Offset: ${DateTime.now().timeZoneOffset}');
+      print('🕐 Time Debug:');
+      print('   Stored Route Start: ${preferences.commuteWindows.start}');
+      print('   Displayed Start Local: ${_formatTimeOfDay(_routeStartTime)}');
+      print('   Stored Route End: ${preferences.commuteWindows.end}');
+      print('   Displayed End Local: ${_formatTimeOfDay(_routeEndTime)}');
     }
   }
 
@@ -155,17 +150,13 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   }
 
   UserPreferences _createPreferencesFromForm() {
-    // Convert local times to UTC for storage
-    final startUtc = CommuteWindows.localTimeOfDayToUtc(_routeStartTime);
-    final endUtc = CommuteWindows.localTimeOfDayToUtc(_routeEndTime);
+    final startStr = CommuteWindows.localTimeOfDayToString(_routeStartTime);
+    final endStr = CommuteWindows.localTimeOfDayToString(_routeEndTime);
 
     if (kDebugMode) {
-      print('🕐 Time Conversion for Storage:');
-      print('   Local Start: ${_formatTimeOfDay(_routeStartTime)}');
-      print('   UTC Start: $startUtc');
-      print('   Local End: ${_formatTimeOfDay(_routeEndTime)}');
-      print('   UTC End: $endUtc');
-      print('   Current Timezone Offset: ${DateTime.now().timeZoneOffset}');
+      print('🕐 Time for Storage:');
+      print('   Start: $startStr');
+      print('   End: $endStr');
     }
 
     return UserPreferences(
@@ -187,7 +178,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         latitude: double.tryParse(_officeLatController.text) ?? 0.0,
         longitude: double.tryParse(_officeLonController.text) ?? 0.0,
       ),
-      commuteWindows: CommuteWindows(start: startUtc, end: endUtc),
+      commuteWindows: CommuteWindows(start: startStr, end: endStr),
     );
   }
 
@@ -203,10 +194,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       });
 
       if (kDebugMode) {
-        final utcTime = CommuteWindows.localTimeOfDayToUtc(picked);
-        print('🕐 Route Start Time Selected:');
-        print('   Local Time: ${_formatTimeOfDay(picked)}');
-        print('   Will be stored as UTC: $utcTime');
+        print('🕐 Route Start Time Selected: ${_formatTimeOfDay(picked)}');
       }
     }
   }
@@ -223,10 +211,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       });
 
       if (kDebugMode) {
-        final utcTime = CommuteWindows.localTimeOfDayToUtc(picked);
-        print('🕐 Route End Time Selected:');
-        print('   Local Time: ${_formatTimeOfDay(picked)}');
-        print('   Will be stored as UTC: $utcTime');
+        print('🕐 Route End Time Selected: ${_formatTimeOfDay(picked)}');
       }
     }
   }
@@ -500,7 +485,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         );
         print('   Total route points: ${routeModel.routePoints.length}');
         print(
-          '   Commute Windows (UTC): Start ${preferences.commuteWindows.start}, End ${preferences.commuteWindows.end}',
+          '   Commute Windows: Start ${preferences.commuteWindows.start}, End ${preferences.commuteWindows.end}',
         );
         print(
           '   Commute Windows (Local): Start ${_formatTimeOfDay(_routeStartTime)}, End ${_formatTimeOfDay(_routeEndTime)}',
@@ -802,7 +787,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
             ),
             const SizedBox(height: 4),
             Text(
-              'Times shown in your local timezone ($timeZoneName, UTC$offsetString)',
+              'Times shown in your local timezone ($timeZoneName, offset $offsetString)',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Theme.of(context).colorScheme.primary,
                 fontStyle: FontStyle.italic,

--- a/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
+++ b/ride_aware_frontend/lib/viewmodels/upcoming_commute_view_model.dart
@@ -107,7 +107,7 @@ class UpcomingCommuteViewModel extends ChangeNotifier {
     final prefs = await _prefsService.loadPreferences();
     final updated = prefs.copyWith(
       commuteWindows: prefs.commuteWindows.copyWith(
-        start: CommuteWindows.localTimeOfDayToUtc(time),
+        start: CommuteWindows.localTimeOfDayToString(time),
       ),
     );
     await _prefsService.savePreferences(updated);

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -36,12 +36,12 @@ class _StatusInfo {
 class UpcomingCommuteAlert extends StatefulWidget {
   final String feedbackSummary;
   final Future<void> Function()? onThresholdUpdated;
-  final Future<void> Function(String rideId, DateTime startUtc,
+  final Future<void> Function(String rideId, DateTime start,
       Map<String, dynamic> threshold)? onRideStarted;
   final Future<void> Function(
       String rideId,
-      DateTime startUtc,
-      DateTime endUtc,
+      DateTime start,
+      DateTime end,
       String status,
       Map<String, dynamic> summary,
       Map<String, dynamic> threshold,
@@ -923,13 +923,13 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
       );
 
       final prefs = await _preferencesService.loadPreferences();
-      final startUtc = CommuteWindows.localTimeOfDayToUtc(
+      final startStr = CommuteWindows.localTimeOfDayToString(
           _routeStartTime ?? prefs.commuteWindows.startLocal);
-      final endUtc = CommuteWindows.localTimeOfDayToUtc(
+      final endStr = CommuteWindows.localTimeOfDayToString(
           _routeEndTime ?? prefs.commuteWindows.endLocal);
       final updatedPrefs = prefs.copyWith(
         weatherLimits: newLimits,
-        commuteWindows: CommuteWindows(start: startUtc, end: endUtc),
+        commuteWindows: CommuteWindows(start: startStr, end: endStr),
       );
 
       final feedbackGiven =


### PR DESCRIPTION
## Summary
- drop all UTC conversions in backend and frontend
- schedule feedback cards exactly one hour after ride and hide before next ride
- store commute and ride timestamps in local time and schedule alerts accordingly

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cec2145a08328a5d5f6f0bfd0ee0f