### PR TITLE
Use local timezone for weather data

### DIFF
--- a/ride_aware_frontend/lib/screens/history_screen.dart
+++ b/ride_aware_frontend/lib/screens/history_screen.dart
@@ -141,7 +141,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
       children: e.weather.map((w) {
         final t = w.tempC != null ? '${w.tempC}°C' : '?°C';
         final wind = w.windMs != null ? '${w.windMs} m/s' : '? m/s';
-        final hhmm = TimeOfDay.fromDateTime(w.tsUtc.toLocal());
+        final hhmm = TimeOfDay.fromDateTime(w.timestamp.toLocal());
         final stamp =
             '${hhmm.hour.toString().padLeft(2, "0")}:${hhmm.minute.toString().padLeft(2, "0")}';
         final cond = w.cond != null ? ' • ${w.cond}' : '';


### PR DESCRIPTION
## Summary
- drop UTC getter from `WeatherPoint` to keep weather timestamps in local time
- show weather chip times using the local timestamp directly

## Testing
- `dart analyze` *(command not found: dart)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cf70867dc8328ad97f06db639f1b0