### PR TITLE
Handle missing ride id in ride history

### DIFF
--- a/ride_aware_frontend/lib/models/ride_history_entry.dart
+++ b/ride_aware_frontend/lib/models/ride_history_entry.dart
@@ -27,8 +27,11 @@ class RideHistoryEntry {
     final endStr = json['end_time'] as String;
     final start = DateTime.parse('${date}T$startStr');
     final end = DateTime.parse('${date}T$endStr');
+    final id = (json['ride_id'] as String?) ??
+        (json['threshold_id'] as String?) ??
+        '';
     return RideHistoryEntry(
-      rideId: json['ride_id'] as String,
+      rideId: id,
       start: start,
       end: end,
       status: json['status'] as String,


### PR DESCRIPTION
## Summary
- make ride history parser tolerate missing `ride_id` by checking `threshold_id` fallback

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689d2e9be15883288aada4f9dab6636b