### PR TITLE
Expand TableCalendar date range

### DIFF
--- a/ride_aware_frontend/lib/screens/history_screen.dart
+++ b/ride_aware_frontend/lib/screens/history_screen.dart
@@ -47,8 +47,8 @@ class _HistoryScreenState extends State<HistoryScreen> {
       body: Column(
         children: [
           TableCalendar<RideHistoryEntry>(
-            firstDay: DateTime.now().subtract(const Duration(days: 30)),
-            lastDay: DateTime.now(),
+            firstDay: DateTime.now().subtract(const Duration(days: 365)),
+            lastDay: DateTime.now().add(const Duration(days: 365)),
             focusedDay: _focusedDay,
             selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
             eventLoader: _getEntriesForDay,


### PR DESCRIPTION
## Summary
- show ride history for a full year past and future by expanding TableCalendar range

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d33f641b8832897e8382b71b7fd54