### PR TITLE
Improve ride history colors

### DIFF
--- a/ride_aware_frontend/lib/screens/history_screen.dart
+++ b/ride_aware_frontend/lib/screens/history_screen.dart
@@ -70,7 +70,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
                 shape: BoxShape.circle,
               ),
               markerDecoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.secondary,
+                color: Theme.of(context).colorScheme.tertiary,
                 shape: BoxShape.circle,
               ),
             ),
@@ -168,11 +168,11 @@ class _HistoryScreenState extends State<HistoryScreen> {
   Color _statusColor(String status) {
     switch (status) {
       case 'alert':
-        return Colors.red.shade100;
+        return Colors.red.shade300;
       case 'warning':
-        return Colors.orange.shade100;
+        return Colors.orange.shade300;
       default:
-        return Colors.green.shade100;
+        return Colors.green.shade300;
     }
   }
 }


### PR DESCRIPTION
## Summary
- enhance calendar event marker color for better visibility
- increase status color contrast in ride history list

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d365191208328a9edf360cfb8d0ac