### PR TITLE
Show ride feedback card when pending

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -85,6 +85,9 @@ class _DashboardScreenState extends State<DashboardScreen>
 
   Future<void> _refreshFeedbackFlag() async {
     final pendingId = await _prefsService.getPendingFeedbackThresholdId();
+    final hasPending = pendingId != null
+        ? true
+        : await _prefsService.hasPendingFeedback();
     final submitted = pendingId != null
         ? await _prefsService.getFeedbackSubmitted(pendingId)
         : false;
@@ -93,7 +96,7 @@ class _DashboardScreenState extends State<DashboardScreen>
     setState(() {
       _pendingFeedbackThresholdId = pendingId;
       _endFeedbackGiven = submitted;
-      _showFeedback = pendingId != null && !submitted && !hideForNextRide;
+      _showFeedback = hasPending && !submitted && !hideForNextRide;
     });
   }
 


### PR DESCRIPTION
## Summary
- Ensure dashboard feedback card appears even if no threshold ID is stored by checking for any pending feedback

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d3c8b32b8832881dffeb0c3306f82