### PR TITLE
Hide feedback card when window closes

### DIFF
--- a/ride_aware_frontend/lib/models/ride_slot.dart
+++ b/ride_aware_frontend/lib/models/ride_slot.dart
@@ -31,6 +31,8 @@ bool shouldShowFeedback({
   if (feedbackAlreadySubmitted) return false;
   final now = nowLocal ?? DateTime.now();
   final win = windowFor(current, next);
-  if (now.isAfter(win.hideAt)) return false;
+  // Hide the card once the window has closed (at hideAt or later)
+  if (!now.isBefore(win.hideAt)) return false;
+  // Show the card once the ride has finished
   return !now.isBefore(win.showAt);
 }

--- a/ride_aware_frontend/test/ride_slot_test.dart
+++ b/ride_aware_frontend/test/ride_slot_test.dart
@@ -1,0 +1,72 @@
+import 'package:test/test.dart';
+import 'package:active_commuter_support/models/ride_slot.dart';
+
+void main() {
+  group('shouldShowFeedback', () {
+    final current = RideSlot(
+      start: DateTime(2024, 1, 1, 8),
+      end: DateTime(2024, 1, 1, 9),
+      rideId: 'ride1',
+    );
+    final next = RideSlot(
+      start: DateTime(2024, 1, 1, 17),
+      end: DateTime(2024, 1, 1, 18),
+      rideId: 'ride2',
+    );
+
+    test('before current ride ends', () {
+      final now = DateTime(2024, 1, 1, 8, 30);
+      final show = shouldShowFeedback(
+        current: current,
+        next: next,
+        feedbackAlreadySubmitted: false,
+        nowLocal: now,
+      );
+      expect(show, isFalse);
+    });
+
+    test('immediately after ride end', () {
+      final now = DateTime(2024, 1, 1, 9);
+      final show = shouldShowFeedback(
+        current: current,
+        next: next,
+        feedbackAlreadySubmitted: false,
+        nowLocal: now,
+      );
+      expect(show, isTrue);
+    });
+
+    test('just before next ride window closes', () {
+      final now = DateTime(2024, 1, 1, 16, 58, 59);
+      final show = shouldShowFeedback(
+        current: current,
+        next: next,
+        feedbackAlreadySubmitted: false,
+        nowLocal: now,
+      );
+      expect(show, isTrue);
+    });
+
+    test('at hide time it disappears', () {
+      final now = DateTime(2024, 1, 1, 16, 59);
+      final show = shouldShowFeedback(
+        current: current,
+        next: next,
+        feedbackAlreadySubmitted: false,
+        nowLocal: now,
+      );
+      expect(show, isFalse);
+    });
+
+    test('feedback already submitted hides card', () {
+      final now = DateTime(2024, 1, 1, 9, 1);
+      final show = shouldShowFeedback(
+        current: current,
+        next: next,
+        feedbackAlreadySubmitted: true,
+        nowLocal: now,
+      );
+      expect(show, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Prevent post-ride feedback card from showing once the next ride’s window opens
- Add tests for ride feedback visibility timing

## Testing
- `pytest`
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4320e86c8328aaa7fc2592d7c14f