### PR TITLE
Add local fallback notifications for feedback and pre-ride alerts

### DIFF
--- a/ride_aware_frontend/lib/screens/dashboard_screen.dart
+++ b/ride_aware_frontend/lib/screens/dashboard_screen.dart
@@ -446,6 +446,7 @@ class _DashboardScreenState extends State<DashboardScreen>
 
                 await _prefsService.setPendingFeedback(DateTime.now());
                 await _prefsService.setPendingFeedbackThresholdId(rideId);
+                await _notificationService.showFeedbackNotification();
               },
             ),
 

--- a/ride_aware_frontend/lib/services/notification_service.dart
+++ b/ride_aware_frontend/lib/services/notification_service.dart
@@ -210,6 +210,24 @@ class NotificationService {
     );
   }
 
+  /// Show a notification warning about upcoming ride conditions
+  Future<void> showPreRideAlert(String message) async {
+    const androidDetails = AndroidNotificationDetails(
+      'pre_ride_channel',
+      'Pre-Ride Alerts',
+      channelDescription: 'Notifications for upcoming ride weather alerts',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+    const notificationDetails = NotificationDetails(android: androidDetails);
+    await _localNotificationsPlugin.show(
+      1,
+      'Weather Alert: Prepare for your ride',
+      message,
+      notificationDetails,
+    );
+  }
+
   /// Check if notifications are enabled
   Future<bool> areNotificationsEnabled() async {
     NotificationSettings settings = await _firebaseMessaging

--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -7,6 +7,7 @@ import '../utils/i18n.dart';
 import '../models/user_preferences.dart';
 import '../services/preferences_service.dart';
 import '../services/api_service.dart';
+import '../services/notification_service.dart';
 import '../screens/wind_map_screen.dart';
 
 // Helper classes defined outside the widget
@@ -77,6 +78,7 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
   final GlobalKey<FormState> _thresholdFormKey = GlobalKey<FormState>();
   bool _showThresholdForm = false;
   bool _isSaving = false;
+  bool _preRideNotificationShown = false;
 
   UserPreferences? _prefs;
 
@@ -96,7 +98,17 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
     _loadPrefs();
   }
 
-  void _onUpdate() => setState(() {});
+  void _onUpdate() {
+    setState(() {});
+    if (!_vm.isLoading &&
+        _vm.result != null &&
+        _vm.result!.issues.isNotEmpty &&
+        !_preRideNotificationShown) {
+      final message = _vm.result!.issues.join(' • ');
+      NotificationService().showPreRideAlert(message);
+      _preRideNotificationShown = true;
+    }
+  }
 
   Future<void> _loadPrefs() async {
     final prefs = await _preferencesService.loadPreferences();
@@ -111,6 +123,7 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
   }
 
   void refreshForecast() {
+    _preRideNotificationShown = false;
     _vm.load();
   }
 


### PR DESCRIPTION
## Summary
- show a local feedback reminder when a ride ends
- surface pre-ride weather issues via a local notification

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5eb89e708328890bbb8fbbf6d824