### PR TITLE
refactor: extract ride feedback card widget

### DIFF
--- a/ride_aware_frontend/lib/widgets/ride_feedback_card.dart
+++ b/ride_aware_frontend/lib/widgets/ride_feedback_card.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'standard_card.dart';
+
+/// Displays feedback status for the most recent ride.
+///
+/// When [feedbackGiven] is false, tapping the card triggers [onTap]
+/// to open the feedback form. A close button is also shown allowing
+/// the user to dismiss the feedback prompt by invoking [onClose].
+class RideFeedbackCard extends StatelessWidget {
+  final bool feedbackGiven;
+  final VoidCallback? onTap;
+  final VoidCallback? onClose;
+
+  const RideFeedbackCard({
+    super.key,
+    required this.feedbackGiven,
+    this.onTap,
+    this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        StandardCard(
+          child: ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(
+              Icons.feedback,
+              color: feedbackGiven
+                  ? Theme.of(context).colorScheme.secondary
+                  : Theme.of(context).colorScheme.error,
+            ),
+            title: Text(
+              feedbackGiven
+                  ? 'Feedback submitted for your last ride'
+                  : 'Feedback available for your last ride',
+            ),
+            subtitle: feedbackGiven
+                ? null
+                : const Text(
+                    'Tap to give feedback or close if your ride was fine.',
+                  ),
+            onTap: feedbackGiven ? null : onTap,
+          ),
+        ),
+        if (!feedbackGiven)
+          Padding(
+            padding: const EdgeInsets.only(top: 8.0, right: 16.0),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                icon: const Icon(Icons.close),
+                label: const Text('Close'),
+                onPressed: onClose,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- extract ride feedback card UI into separate widget
- add helper for opening feedback form and wire it to new card

## Testing
- `flutter format lib/screens/dashboard_screen.dart lib/widgets/ride_feedback_card.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689defdd902c8328b7c20ca1046a8ffb