### PR TITLE
Expand pre-ride alert notification conditions

### DIFF
--- a/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
+++ b/ride_aware_frontend/lib/widgets/upcoming_commute_alert.dart
@@ -102,11 +102,17 @@ class UpcomingCommuteAlertState extends State<UpcomingCommuteAlert> {
     setState(() {});
     if (!_vm.isLoading &&
         _vm.result != null &&
-        _vm.result!.issues.isNotEmpty &&
         !_preRideNotificationShown) {
-      final message = _vm.result!.issues.join(' • ');
-      NotificationService().showPreRideAlert(message);
-      _preRideNotificationShown = true;
+      final r = _vm.result!;
+      final hasProblems =
+          r.status != 'ok' || r.issues.isNotEmpty || r.borderline.isNotEmpty;
+      if (hasProblems) {
+        final parts = [...r.issues, ...r.borderline];
+        final message =
+            parts.isNotEmpty ? parts.join(' • ') : 'Check ride conditions';
+        NotificationService().showPreRideAlert(message);
+        _preRideNotificationShown = true;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Show pre-ride notifications whenever commute evaluation reports alerts or borderline conditions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e00ec82588328a90f74d3021cf135